### PR TITLE
setting up crab config directory + including link to link mapping tools

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bye_splits/crab/realistic-signaldriven-elinks"]
+	path = bye_splits/crab/realistic-signaldriven-elinks
+	url = git@github.com:portalesHEP/realistic-signaldriven-elinks.git


### PR DESCRIPTION
@bfonta FYI 

The "link mapping tools" are require to define a mapping adapted to the BC+STC algorithm using the "old" V2 geometry. BC+STC can't yet be used with the current V3 geometry; the adaptation is apparently WIP.