### PR TITLE
Add energy threshold slider

### DIFF
--- a/bye_splits/data_handle/data_handle.py
+++ b/bye_splits/data_handle/data_handle.py
@@ -19,7 +19,7 @@ class EventDataParticle:
         assert particles in ('photons', 'electrons')
         self.particles = particles
         self.tag = self.particles + '_' + tag
-        with open(params.viz_kw['CfgEventPath'], 'r') as afile:
+        with open(params.viz_kw['CfgDataPath'], 'r') as afile:
             self.config = yaml.safe_load(afile)
 
         data_suffix = 'skim' + ('_small' if debug else '')

--- a/bye_splits/data_handle/event.py
+++ b/bye_splits/data_handle/event.py
@@ -20,7 +20,7 @@ class EventData(BaseData):
     def __init__(self, inname='', tag='v0', default_events=[], reprocess=False, logger=None):
         super().__init__(inname, tag, reprocess, logger)
         
-        with open(params.viz_kw['CfgEventPath'], 'r') as afile:
+        with open(params.viz_kw['CfgDataPath'], 'r') as afile:
             cfg = yaml.safe_load(afile)
             self.var = cfg['varEvents']
             

--- a/bye_splits/data_handle/geometry.py
+++ b/bye_splits/data_handle/geometry.py
@@ -28,7 +28,7 @@ class GeometryData(BaseData):
         super().__init__(inname, 'geom', reprocess, logger)
         self.dataset = None
         self.dname = 'tc'
-        with open(params.viz_kw['CfgEventPath'], 'r') as afile:
+        with open(params.viz_kw['CfgDataPath'], 'r') as afile:
             cfg = yaml.safe_load(afile)
             self.var = common.dot_dict(cfg['varGeometry'])
 

--- a/bye_splits/data_handle/geometry.py
+++ b/bye_splits/data_handle/geometry.py
@@ -19,6 +19,11 @@ from utils import params, common
 from data_handle.base import BaseData
 
 class GeometryData(BaseData):
+    """
+    Handles V11 HGCAL geometry.
+    Uses the orientation #1 of bottom row of slide 4 in
+    https://indico.cern.ch/event/1111846/contributions/4675223/attachments/2372915/4052852/PartialsRotation.pdf
+    """
     def __init__(self, inname='', reprocess=False, logger=None):
         super().__init__(inname, 'geom', reprocess, logger)
         self.dataset = None
@@ -31,58 +36,75 @@ class GeometryData(BaseData):
         self.readvars.remove(self.var.wvs)
         self.readvars.remove(self.var.c)
 
+        self.cu, self.cv = 'triggercellu', 'triggercellv'
+        self.wu, self.wv = 'waferu', 'waferv'
+
+        ## geometry-specific parameters
+        self.waferWidth = 1 #this defines all other sizes
+        self.N = 4 #number of cells per wafer side
+        self.c30 = np.sqrt(3)/2 #cossine of 30 degrees
+        self.t30 = 1/np.sqrt(3) #tangent of 30 degrees
+        self.R = self.waferWidth / (3 * self.N)
+        self.r = self.R * self.c30
+
     def filter_columns(self, d):
         """Filter some columns to reduce memory usage"""
         cols_to_remove = ['x', 'y', 'z', 'color']
         cols = [x for x in d.fields if x not in cols_to_remove]
         return d[cols]
 
+    def cell_location(self, df):
+        """Filter TC location in wafer: up-right, up-left and bottom."""
+        conds = {'UL': ~((df[self.cu] >= self.N) & (df[self.cu] > df[self.cv])),
+                 'UR': ~((df[self.cv] >= self.N) & (df[self.cu] <= df[self.cv])),
+                 'B':  ~((df[self.cu] < self.N) & (df[self.cv] < self.N))}
+        df['cloc'] = np.nan
+        df['cloc'] = df['cloc'].where(conds['B'], 'B')
+        df['cloc'] = df['cloc'].where(conds['UL'], 'UL')
+        df['cloc'] = df['cloc'].where(conds['UR'], 'UR')
+        return df
+
     def region_selection(self, df, region=None):
+        """Select a specific geometry region. Used mostly for debugging."""
         if region is not None:
             regions = ('inside', 'periphery')
             assert region in regions
             if region == 'inside':
-                df = df[((df['waferu']==3) & (df['waferv']==3)) |
-                        ((df['waferu']==3) & (df['waferv']==4)) |
-                        ((df['waferu']==4) & (df['waferv']==3)) |
-                        ((df['waferu']==4) & (df['waferv']==4))]
+                df = df[((df[self.wu]==3) & (df[self.wv]==3)) |
+                        ((df[self.wu]==3) & (df[self.wv]==4)) |
+                        ((df[self.wu]==4) & (df[self.wv]==3)) |
+                        ((df[self.wu]==4) & (df[self.wv]==4))]
 
             elif region == 'periphery':
-                df = df[((df['waferu']==-6) & (df['waferv']==3)) |
-                        ((df['waferu']==-6) & (df['waferv']==4)) |
-                        ((df['waferu']==-7) & (df['waferv']==3)) |
-                        ((df['waferu']==-8) & (df['waferv']==2)) |
-                        ((df['waferu']==-8) & (df['waferv']==1)) |
-                        ((df['waferu']==-7) & (df['waferv']==2))
+                df = df[((df[self.wu]==-6) & (df[self.wv]==3)) |
+                        ((df[self.wu]==-6) & (df[self.wv]==4)) |
+                        ((df[self.wu]==-7) & (df[self.wv]==3)) |
+                        ((df[self.wu]==-8) & (df[self.wv]==2)) |
+                        ((df[self.wu]==-8) & (df[self.wv]==1)) |
+                        ((df[self.wu]==-7) & (df[self.wv]==2))
                         ]
 
-        # df = df[df.layer<=9]
+        # df = df[df.layer<9]
         # df = df[df.waferpart==0]
         return df
 
     def prepare_for_display(self, df, library='bokeh'):
+        """Prepares dataframe to be displayed by certain libraries."""
         libraries = ('bokeh', )
         assert library in libraries
         
-        c30, s30, t30 = np.sqrt(3)/2, 1/2, 1/np.sqrt(3)
-        N = 4
-        waferWidth = 1
-        R = waferWidth / (3 * N)
-        r = R * c30
-        cellDistX = waferWidth/8.
-        cellDistY = cellDistX * t30
+        cellDistX = self.waferWidth/8.
+        cellDistY = cellDistX * self.t30
 
-        scu, scv = 'triggercellu', 'triggercellv'
-        swu, swv = 'waferu', 'waferv'
-        df.loc[:, 'wafer_shift_x'] = (-2*df[swu] + df[swv])*waferWidth/2
-        df.loc[:, 'wafer_shift_y'] = c30*df[swv]
+        df.loc[:, 'wafer_shift_x'] = (-2*df[self.wu] + df[self.wv])*self.waferWidth/2
+        df.loc[:, 'wafer_shift_y'] = self.c30*df[self.wv]
     
-        cells_conversion = (lambda cu,cv: (1.5*(cv-cu)+0.5) * R,
-                            lambda cu,cv: (cv+cu-2*N+1) * r) #orientation 6
+        cells_conversion = (lambda cu,cv: (1.5*(cv-cu)+0.5) * self.R,
+                            lambda cu,cv: (cv+cu-2*N+1) * self.r) #orientation 6
 
-        univ_wcenterx = (1.5*(3-3) + 0.5)*R + cellDistX
-        univ_wcentery = (3 + 3 - 2*N + 1) * r + 3*cellDistY/2
-        scale_x, scale_y = waferWidth/2, waferWidth/(2*c30)
+        univ_wcenterx = (1.5*(3-3) + 0.5)*self.R + cellDistX
+        univ_wcentery = (3 + 3 - 2*self.N + 1) * self.r + 3*cellDistY/2
+        scale_x, scale_y = self.waferWidth/2, self.waferWidth/(2*self.c30)
         
         xcorners, ycorners = ([] for _ in range(2))
         xcorners.append(univ_wcenterx - scale_x)
@@ -98,125 +120,84 @@ class GeometryData(BaseData):
         ycorners.append(univ_wcentery + ysub)
         ycorners.append(univ_wcentery + scale_y)
         ycorners.append(univ_wcentery + ysub)
-    
-        def masks_location(location, ax, ay):
-            """Filter TC location in wafer: up-right, up-left and bottom.
-            The x/y location depends on the wafer orientation."""
-            ux = np.sort(ax.unique())
-            uy = np.sort(ay.unique())
-            if len(ux)==0 or len(uy)==0:
-                return pd.Series(dtype=float)
-        
-            if len(ux) != 2*N: #full wafers
-                m = 'Length unique X values vs expected for full wafers: {} vs {}\n'.format(len(ux), 2*N)
-                m += 'Fix.'
-                raise AssertionError(m)
-            if len(uy) != 4*N-1: #full wafers
-                m = 'Length unique Y values vs expected for full wafers: {} vs {}\n'.format(len(uy), 4*N-1)
-                m += 'Fix.'
-                raise AssertionError(m)
-
-            b = (-1/12, 0.)
-            fx, fy = 1/8, (1/8)*t30 #multiplicative factors: cells are evenly spaced
-            eps = 0.02 #epsilon, create an interval around the true values
-            cx = abs(round((ux[0]-b[0])/fx)) 
-            cy = abs(round((uy[N-1]-b[1])/fy))
-            # -0.216, -0.144, -0.072, -0.000 /// +0.072, -0.000, -.072, -0.144
-
-            filt_UL = ((ax > b[0]-(cx-0)*fx-eps) & (ax < b[0]-(cx-0)*fx+eps) & (ay > b[1]-(cy-0)*fy-eps) |
-                       (ax > b[0]-(cx-1)*fx-eps) & (ax < b[0]-(cx-1)*fx+eps) & (ay > b[1]-(cy-1)*fy-eps) |
-                       (ax > b[0]-(cx-2)*fx-eps) & (ax < b[0]-(cx-2)*fx+eps) & (ay > b[1]-(cy-2)*fy-eps) |
-                       (ax > b[0]-(cx-3)*fx-eps) & (ax < b[0]-(cx-3)*fx+eps) & (ay > b[1]-(cy-3)*fy-eps))
             
-            filt_UR = ((ax > b[0]-(cx-4)*fx-eps) & (ax < b[0]-(cx-4)*fx+eps) & (ay > b[1]-(cy-4)*fy-eps) |
-                       (ax > b[0]-(cx-5)*fx-eps) & (ax < b[0]-(cx-5)*fx+eps) & (ay > b[1]-(cy-3)*fy-eps) |
-                       (ax > b[0]-(cx-6)*fx-eps) & (ax < b[0]-(cx-6)*fx+eps) & (ay > b[1]-(cy-2)*fy-eps) |
-                    (ax > b[0]-(cx-7)*fx-eps) & (ax < b[0]-(cx-7)*fx+eps) & (ay > b[1]-(cy-1)*fy-eps))
-
-            if location == 'UL':
-                return filt_UL
-            elif location == 'UR':
-                return filt_UR
-            else: #bottom
-                return (~filt_UL & ~filt_UR)
-
         xpoint, x0, x1, x2, x3 = ({} for _ in range(5))
         ypoint, y0, y1, y2, y3 = ({} for _ in range(5))
         xaxis, yaxis = ({} for _ in range(2))
 
-        df.loc[:, 'tc_x_center'] = (1.5*(df[scv]-df[scu])+0.5) * R #orientation 6
-        df.loc[:, 'tc_y_center'] = (df[scv]+df[scu]-2*N+1) * r #orientation 6
-        df.loc[:, 'tc_x'] = df.wafer_shift_x + df['tc_x_center']
-        df.loc[:, 'tc_y'] = df.wafer_shift_y + df['tc_y_center']
-        wcenter_x = df.wafer_shift_x + univ_wcenterx # fourth vertex (center) for cu/cv=(3,3)
-        wcenter_y = df.wafer_shift_y + univ_wcentery # fourth vertex (center) for cu/cv=(3,3)
+        # orientation 6
+        df['tc_x_center'] = (1.5*(df[self.cv]-df[self.cu])+0.5) * self.R
+        df['tc_y_center'] = (df[self.cv]+df[self.cu]-2*self.N+1) * self.r
+        df['tc_x'] = df.wafer_shift_x + df['tc_x_center']
+        df['tc_y'] = df.wafer_shift_y + df['tc_y_center']
+        df['wx_center'] = df.wafer_shift_x + univ_wcenterx # fourth vertex (center) for cu/cv=(3,3)
+        df['wy_center'] = df.wafer_shift_y + univ_wcentery # fourth vertex (center) for cu/cv=(3,3)
+
+        df = self.cell_location(df)
         
-        for loc_key in ('UL', 'UR', 'B'):
-            masks_loc = masks_location(loc_key, df['tc_x_center'], df['tc_y_center'])
-            cx_d, cy_d = df['tc_x'][masks_loc], df['tc_y'][masks_loc]
-            wc_x, wc_y = wcenter_x[masks_loc], wcenter_y[masks_loc]
+        for kloc in ('UL', 'UR', 'B'):
+            cx_d, cy_d = df[df.cloc==kloc]['tc_x'], df[df.cloc==kloc]['tc_y']
+            wc_x, wc_y = df[df.cloc==kloc]['wx_center'], df[df.cloc==kloc]['wy_center']
             
             # x0 refers to the x position the lefmost, down corner all diamonds (TCs)
             # x1, x2, x3 are defined in a counter clockwise fashion
             # same for y0, y1, y2 and y3
             # tc positions refer to the center of the diamonds
-            if loc_key == 'UL':
-                x0.update({loc_key: cx_d})
-            elif loc_key == 'UR':
-                x0.update({loc_key: cx_d})
+            if kloc == 'UL':
+                x0.update({kloc: cx_d})
+            elif kloc == 'UR':
+                x0.update({kloc: cx_d})
             else:
-                x0.update({loc_key: cx_d - cellDistX})
+                x0.update({kloc: cx_d - cellDistX})
                 
-            x1.update({loc_key: x0[loc_key][:] + cellDistX})
-            if loc_key in ('UL', 'UR'):
-                x2.update({loc_key: x1[loc_key]})
-                x3.update({loc_key: x0[loc_key]})
+            x1.update({kloc: x0[kloc][:] + cellDistX})
+            if kloc in ('UL', 'UR'):
+                x2.update({kloc: x1[kloc]})
+                x3.update({kloc: x0[kloc]})
             else:
-                x2.update({loc_key: x1[loc_key] + cellDistX})
-                x3.update({loc_key: x1[loc_key]})
+                x2.update({kloc: x1[kloc] + cellDistX})
+                x3.update({kloc: x1[kloc]})
 
-            if loc_key == 'UL':
-                y0.update({loc_key: cy_d})
-            elif loc_key == 'UR':
-                y0.update({loc_key: cy_d})
+            if kloc == 'UL':
+                y0.update({kloc: cy_d})
+            elif kloc == 'UR':
+                y0.update({kloc: cy_d})
             else:
-                y0.update({loc_key: cy_d + cellDistY})
+                y0.update({kloc: cy_d + cellDistY})
 
-            if loc_key in ('UR', 'B'):
-                y1.update({loc_key: y0[loc_key][:] - cellDistY})
+            if kloc in ('UR', 'B'):
+                y1.update({kloc: y0[kloc][:] - cellDistY})
             else:
-                y1.update({loc_key: y0[loc_key][:] + cellDistY})
-            if loc_key in ('B'):
-                y2.update({loc_key: y0[loc_key][:]})
+                y1.update({kloc: y0[kloc][:] + cellDistY})
+            if kloc in ('B'):
+                y2.update({kloc: y0[kloc][:]})
             else:
-                y2.update({loc_key: y1[loc_key][:] + 2*cellDistY})
-            if loc_key in ('UL', 'UR'):
-                y3.update({loc_key: y0[loc_key][:] + 2*cellDistY})
+                y2.update({kloc: y1[kloc][:] + 2*cellDistY})
+            if kloc in ('UL', 'UR'):
+                y3.update({kloc: y0[kloc][:] + 2*cellDistY})
             else:
-                y3.update({loc_key: y0[loc_key][:] + cellDistY})
+                y3.update({kloc: y0[kloc][:] + cellDistY})
 
-            angle = 0#5*np.pi/3
-            # orientation 1 of bottom row of slide 4 in
-            # https://indico.cern.ch/event/1111846/contributions/4675223/attachments/2372915/4052852/PartialsRotation.pdf
-            x0[loc_key], y0[loc_key] = self.rotate(angle, x0[loc_key], y0[loc_key], wc_x, wc_y)
-            x1[loc_key], y1[loc_key] = self.rotate(angle, x1[loc_key], y1[loc_key], wc_x, wc_y)
-            x2[loc_key], y2[loc_key] = self.rotate(angle, x2[loc_key], y2[loc_key], wc_x, wc_y)
-            x3[loc_key], y3[loc_key] = self.rotate(angle, x3[loc_key], y3[loc_key], wc_x, wc_y)
+            angle = 5*np.pi/3
+            x0[kloc], y0[kloc] = self.rotate(angle, x0[kloc], y0[kloc], wc_x, wc_y)
+            x1[kloc], y1[kloc] = self.rotate(angle, x1[kloc], y1[kloc], wc_x, wc_y)
+            x2[kloc], y2[kloc] = self.rotate(angle, x2[kloc], y2[kloc], wc_x, wc_y)
+            x3[kloc], y3[kloc] = self.rotate(angle, x3[kloc], y3[kloc], wc_x, wc_y)
             
             keys = ['pos0','pos1','pos2','pos3']
             xaxis.update({
-                loc_key: pd.concat([x0[loc_key],x1[loc_key],x2[loc_key],x3[loc_key]],
+                kloc: pd.concat([x0[kloc],x1[kloc],x2[kloc],x3[kloc]],
                                    axis=1, keys=keys)})
             yaxis.update(
-                {loc_key: pd.concat([y0[loc_key],y1[loc_key],y2[loc_key],y3[loc_key]],
+                {kloc: pd.concat([y0[kloc],y1[kloc],y2[kloc],y3[kloc]],
                                     axis=1, keys=keys)})
             
-            xaxis[loc_key]['new'] = [[[[round(val, 3) for val in sublst]]]
-                                     for sublst in xaxis[loc_key].values.tolist()]
-            yaxis[loc_key]['new'] = [[[[round(val, 3) for val in sublst]]]
-                                     for sublst in yaxis[loc_key].values.tolist()]
-            xaxis[loc_key] = xaxis[loc_key].drop(keys, axis=1)
-            yaxis[loc_key] = yaxis[loc_key].drop(keys, axis=1)
+            xaxis[kloc]['new'] = [[[[round(val, 3) for val in sublst]]]
+                                     for sublst in xaxis[kloc].values.tolist()]
+            yaxis[kloc]['new'] = [[[[round(val, 3) for val in sublst]]]
+                                     for sublst in yaxis[kloc].values.tolist()]
+            xaxis[kloc] = xaxis[kloc].drop(keys, axis=1)
+            yaxis[kloc] = yaxis[kloc].drop(keys, axis=1)
 
         df.loc[:, 'diamond_x'] = pd.concat(xaxis.values())
         df.loc[:, 'diamond_y'] = pd.concat(yaxis.values())
@@ -239,6 +220,7 @@ class GeometryData(BaseData):
         return df
 
     def provide(self, region=None):
+        """Provides a processed geometry dataframe to the client."""
         if not os.path.exists(self.outpath) or self.reprocess:
             if self.logger is not None:
                 self.logger.info('Storing geometry data...')
@@ -263,6 +245,7 @@ class GeometryData(BaseData):
         return ret_x, ret_y
 
     def select(self):
+        """Performs data selection for performance."""
         with up.open(self.inpath) as f:
             tree = f[ os.path.join('hgcaltriggergeomtester', 'TreeTriggerCells') ]
             if self.logger is not None:
@@ -287,6 +270,7 @@ class GeometryData(BaseData):
         return data
 
     def store(self):
+        """Stores the data selection in a parquet file for quicker access."""
         ds = self.select()
         if os.path.exists(self.outpath):
             os.remove(self.outpath)

--- a/bye_splits/data_handle/geometry.py
+++ b/bye_splits/data_handle/geometry.py
@@ -195,7 +195,7 @@ class GeometryData(BaseData):
             else:
                 y3.update({loc_key: y0[loc_key][:] + cellDistY})
 
-            angle = 5*np.pi/3
+            angle = 0#5*np.pi/3
             # orientation 1 of bottom row of slide 4 in
             # https://indico.cern.ch/event/1111846/contributions/4675223/attachments/2372915/4052852/PartialsRotation.pdf
             x0[loc_key], y0[loc_key] = self.rotate(angle, x0[loc_key], y0[loc_key], wc_x, wc_y)
@@ -238,7 +238,7 @@ class GeometryData(BaseData):
         df = df.drop(xcorners_str + ycorners_str + ['tc_x_center', 'tc_y_center'], axis=1)
         return df
 
-    def provide(self):
+    def provide(self, region=None):
         if not os.path.exists(self.outpath) or self.reprocess:
             if self.logger is not None:
                 self.logger.info('Storing geometry data...')
@@ -250,7 +250,7 @@ class GeometryData(BaseData):
             ds = ak.from_parquet(self.outpath)
             ds = self.filter_columns(ds)
             ds = ak.to_dataframe(ds)
-            ds = self.region_selection(ds, region=None)
+            ds = self.region_selection(ds, region)
             self.dataset = self.prepare_for_display(ds)
         
         return self.dataset

--- a/bye_splits/plot/display/main.py
+++ b/bye_splits/plot/display/main.py
@@ -84,7 +84,7 @@ for k in (('photons', 'electrons') if mode=='ev' else ('Geometry',)):
     cds_data[k] = get_data(evs, k)[mode]
     elements[k] = {'source': bmd.ColumnDataSource(data=cds_data[k])}
     if mode=='ev':
-        elements[k].update({'textinput': bmd.TextInput(placeholder='event number', height=40,
+        elements[k].update({'textinput': bmd.TextInput(placeholder=str(def_evs[k][0]), height=40,
                                                        sizing_mode='stretch_width'),
                             'dropdown': bmd.Dropdown(label='Default Events', button_type='primary',
                                                     menu=def_ev_text[k], height=40)})

--- a/bye_splits/plot/display/main.py
+++ b/bye_splits/plot/display/main.py
@@ -43,7 +43,7 @@ data_particle = {
     'electrons': EventDataParticle(particles='electrons', **data_part_opt)}
 geom_data = GeometryData(inname='test_triggergeom.root',
                          reprocess=False, logger=log)
-mode = 'ev'
+mode = 'geom'
 
 def common_props(p):
     p.output_backend = 'svg'

--- a/bye_splits/plot/display/main.py
+++ b/bye_splits/plot/display/main.py
@@ -84,7 +84,7 @@ for k in (('photons', 'electrons') if mode=='ev' else ('Geometry',)):
     cds_data[k] = get_data(evs, k)[mode]
     elements[k] = {'source': bmd.ColumnDataSource(data=cds_data[k])}
     if mode=='ev':
-        elements[k].update({'textinput': bmd.TextInput(placeholder='specify an event', height=40,
+        elements[k].update({'textinput': bmd.TextInput(placeholder='event number', height=40,
                                                        sizing_mode='stretch_width'),
                             'dropdown': bmd.Dropdown(label='Default Events', button_type='primary',
                                                     menu=def_ev_text[k], height=40)})
@@ -178,11 +178,13 @@ def display():
         # find dataset minima and maxima
         cur_xmax, cur_ymax = -1e9, -1e9
         cur_xmin, cur_ymin = 1e9, 1e9
-        for ex,ey in zip(vsrc.data['diamond_x'],vsrc.data['diamond_y']):
-            if max(ex[0][0]) > cur_xmax: cur_xmax = max(ex[0][0])
-            if min(ex[0][0]) < cur_xmin: cur_xmin = min(ex[0][0])
-            if max(ey[0][0]) > cur_ymax: cur_ymax = max(ey[0][0])
-            if min(ey[0][0]) < cur_ymin: cur_ymin = min(ey[0][0])
+        for ex,ey,ee in zip(vsrc.data['diamond_x'],vsrc.data['diamond_y'],vsrc.data['good_tc_mipPt']):
+            if ee > cfg_prod['mipThreshold']: #cut replicates what is done in the default `view_en`
+                if max(ex[0][0]) > cur_xmax: cur_xmax = max(ex[0][0])
+                if min(ex[0][0]) < cur_xmin: cur_xmin = min(ex[0][0])
+                if max(ey[0][0]) > cur_ymax: cur_ymax = max(ey[0][0])
+                if min(ey[0][0]) < cur_ymin: cur_ymin = min(ey[0][0])
+                    
         # force matching ratio to avoid distortions
         distx, disty = cur_xmax-cur_xmin, cur_ymax-cur_ymin
         if distx > disty:

--- a/bye_splits/plot/display/main.py
+++ b/bye_splits/plot/display/main.py
@@ -154,14 +154,16 @@ def display():
                """)
 
         if mode == 'ev':
-            view_cells = bmd.CDSView(filter=filt_layers & filt_en)
+            all_filters = filt_layers & filt_en
         else:
-            view_cells = bmd.CDSView(filter=filt_layers)
+            all_filters = filt_layers
+
+        view_cells = bmd.CDSView(filter=all_filters)
         # modules are duplicated for cells lying in the same wafer
         # we want to avoid drawing the same module multiple times
         view_modules = (~cds_data[ksrc].duplicated(subset=['layer', 'waferu', 'waferv'])).tolist()
         #view_modules = bmd.CDSView(filter=filt_layers & bmd.BooleanFilter(view_modules))
-        view_modules = bmd.CDSView(filter=filt_layers)
+        view_modules = bmd.CDSView(filter=all_filters)
 
         ####### (u,v) plots ################################################################
         # p_uv = figure(width=width, height=height,

--- a/bye_splits/utils/params.py
+++ b/bye_splits/utils/params.py
@@ -23,7 +23,8 @@ viz_kw = {
     'DataPath': Path(EOSDataFolder),
     'OutPath': Path(EOSDataFolder),
     'LocalPath': Path(__file__).parents[2] / LocalDataFolder,
-    'CfgEventPath': Path(__file__).parents[2] / 'bye_splits/data_handle/config.yaml',
+    'CfgProdPath': Path(__file__).parents[2] / 'bye_splits/production/prod_params.yaml',
+    'CfgDataPath': Path(__file__).parents[2] / 'bye_splits/data_handle/config.yaml',
 }
 
 base_kw = {


### PR DESCRIPTION
- Strongly simplify the legacy filtering of cell location within a wafer (upper-left, upper-right or bottom, modifications in ```bye_splits/data_handle/geometry.py```)

- It is now possible to control the trigger cell energy threshold with a slider. The initial and minimum value are taken from the same configuration file used during the skimming, making thus sure the display initially shows all trigger cells present in the skimmed input ```ROOT``` file.

