### PR TITLE
Correct absolute Trigger Cell position

### DIFF
--- a/bye_splits/data_handle/config.yaml
+++ b/bye_splits/data_handle/config.yaml
@@ -2,6 +2,10 @@ defaultEvents:
     photons: [4681, 4677]
     electrons: [92243, 92244]
 
+geometry:
+    waferSize: 16.64408
+    sensorSeparation: 0.1
+
 varEvents:
     event: 'event'
     wu: 'good_tc_waferu'
@@ -26,3 +30,4 @@ varGeometry:
     c: 'color'
     orient: 'waferorient'
     part: 'waferpart'
+

--- a/bye_splits/data_handle/geometry.py
+++ b/bye_splits/data_handle/geometry.py
@@ -79,6 +79,7 @@ class GeometryData(BaseData):
     def cell_location_shift(self, df):
         """
         Shift the position of TCs according to their location to allow an aligned display.
+        The true cell position becomes however more distant from the displayed cell center.
         """
         df.loc[:, 'tc_y'] = np.where(df['cloc']=='UR', df['tc_y']+self.cellDistY, df['tc_y'])
         df.loc[:, 'tc_x'] = np.where(df['cloc']=='B', df['tc_x']+self.cellDistX/2, df['tc_x'])
@@ -156,9 +157,9 @@ class GeometryData(BaseData):
         df['wy_center'] = df.wafer_shift_y + univ_wcentery # fourth vertex (center) for cu/cv=(3,3)
 
         df = self.cell_location(df)
-        df = self.cell_location_shift(df)
+        # df = self.cell_location_shift(df)
 
-        angle = 0#5*np.pi/3 #CHANGE!!!!!!!!!        
+        angle = 0 # must be changed for different wafer orientations
         for kloc in ('UL', 'UR', 'B'):
             cx_d, cy_d = df[df.cloc==kloc]['tc_x'], df[df.cloc==kloc]['tc_y']
             wc_x, wc_y = df[df.cloc==kloc]['wx_center'], df[df.cloc==kloc]['wy_center']

--- a/bye_splits/data_handle/geometry.py
+++ b/bye_splits/data_handle/geometry.py
@@ -40,41 +40,62 @@ class GeometryData(BaseData):
         self.wu, self.wv = 'waferu', 'waferv'
 
         ## geometry-specific parameters
-        self.waferWidth = 1 #this defines all other sizes
+        self.waferWidth = cfg['geometry']['waferSize'] #this defines all other sizes
+        self.sensorSeparation = cfg['geometry']['sensorSeparation']
         self.N = 4 #number of cells per wafer side
         self.c30 = np.sqrt(3)/2 #cossine of 30 degrees
         self.t30 = 1/np.sqrt(3) #tangent of 30 degrees
         self.R = self.waferWidth / (3 * self.N)
         self.r = self.R * self.c30
+        self.cellDistX = self.waferWidth/8.
+        self.cellDistY = self.cellDistX * self.t30
 
     def filter_columns(self, d):
         """Filter some columns to reduce memory usage"""
-        cols_to_remove = ['x', 'y', 'z', 'color']
+        #cols_to_remove = ['x', 'y', 'z', 'color']
+        cols_to_remove = ['z', 'color']
         cols = [x for x in d.fields if x not in cols_to_remove]
         return d[cols]
 
     def cell_location(self, df):
-        """Filter TC location in wafer: up-right, up-left and bottom."""
-        conds = {'UL': ~((df[self.cu] >= self.N) & (df[self.cu] > df[self.cv])),
-                 'UR': ~((df[self.cv] >= self.N) & (df[self.cu] <= df[self.cv])),
-                 'B':  ~((df[self.cu] < self.N) & (df[self.cv] < self.N))}
+        """
+        Filter TC location in wafer based on the orientation: up-right, up-left and bottom.
+        In V11 "orientation 0" actually corresponds to 6, as the concept of orientation is only introduced for later versions.
+        """
+        conds = {'UL': ~(((df['waferorient']==6) & (df[self.cu] >= self.N) & (df[self.cu] > df[self.cv])) |
+                         ((df['waferorient']<6) & (df[self.cv] < self.N) & (df[self.cu] > df[self.cv]))),
+
+                 'UR': ~(((df['waferorient']==6) & (df[self.cv] >= self.N) & (df[self.cu] <= df[self.cv])) |
+                         ((df['waferorient']<6) & (df[self.cv] >= self.N) & (df[self.cu] >= self.N))),
+
+                 'B':  ~(((df['waferorient']==6) & (df[self.cu] < self.N) & (df[self.cv] < self.N)) |
+                         ((df['waferorient']<6) & (df[self.cu] < self.N) & (df[self.cv] >= df[self.cu])))}
         df['cloc'] = np.nan
         df['cloc'] = df['cloc'].where(conds['B'], 'B')
         df['cloc'] = df['cloc'].where(conds['UL'], 'UL')
         df['cloc'] = df['cloc'].where(conds['UR'], 'UR')
         return df
 
+    def cell_location_shift(self, df):
+        """
+        Shift the position of TCs according to their location to allow an aligned display.
+        """
+        df.loc[:, 'tc_y'] = np.where(df['cloc']=='UR', df['tc_y']+self.cellDistY, df['tc_y'])
+        df.loc[:, 'tc_x'] = np.where(df['cloc']=='B', df['tc_x']+self.cellDistX/2, df['tc_x'])
+        df.loc[:, 'tc_y'] = np.where(df['cloc']=='B', df['tc_y']+self.cellDistY/2, df['tc_y'])
+        return df
+
     def region_selection(self, df, region=None):
         """Select a specific geometry region. Used mostly for debugging."""
         if region is not None:
-            regions = ('inside', 'periphery')
+            regions = ('inside', 'periphery', 'wafer')
             assert region in regions
             if region == 'inside':
                 df = df[((df[self.wu]==3) & (df[self.wv]==3)) |
                         ((df[self.wu]==3) & (df[self.wv]==4)) |
                         ((df[self.wu]==4) & (df[self.wv]==3)) |
                         ((df[self.wu]==4) & (df[self.wv]==4))]
-
+     
             elif region == 'periphery':
                 df = df[((df[self.wu]==-6) & (df[self.wv]==3)) |
                         ((df[self.wu]==-6) & (df[self.wv]==4)) |
@@ -83,6 +104,9 @@ class GeometryData(BaseData):
                         ((df[self.wu]==-8) & (df[self.wv]==1)) |
                         ((df[self.wu]==-7) & (df[self.wv]==2))
                         ]
+
+            elif region == 'wafer':
+                df = df[((df[self.wu]==3) & (df[self.wv]==3))]
 
         # df = df[df.layer<9]
         # df = df[df.waferpart==0]
@@ -93,17 +117,16 @@ class GeometryData(BaseData):
         libraries = ('bokeh', )
         assert library in libraries
         
-        cellDistX = self.waferWidth/8.
-        cellDistY = cellDistX * self.t30
-
-        df.loc[:, 'wafer_shift_x'] = (-2*df[self.wu] + df[self.wv])*self.waferWidth/2
-        df.loc[:, 'wafer_shift_y'] = self.c30*df[self.wv]
+        df['wafer_shift_x'] = (-2*df[self.wu] + df[self.wv])*(self.waferWidth+self.sensorSeparation)/2
+        df['wafer_shift_y'] = (self.c30*df[self.wv])*(self.waferWidth+self.sensorSeparation)
     
-        cells_conversion = (lambda cu,cv: (1.5*(cv-cu)+0.5) * self.R,
-                            lambda cu,cv: (cv+cu-2*N+1) * self.r) #orientation 6
+        # cells_conversion = (lambda cu,cv: (1.5*(cv-cu)+0.5) * self.R,
+        #                     lambda cu,cv: (cv+cu-2*self.N+1) * self.r) #orientation 6
+        cells_conversion = (lambda cu,cv: (1.5*(cv-self.N)+1) * self.R,
+                            lambda cu,cv: (2*cu-cv-self.N) * self.r) #orientation 7
 
-        univ_wcenterx = (1.5*(3-3) + 0.5)*self.R + cellDistX
-        univ_wcentery = (3 + 3 - 2*self.N + 1) * self.r + 3*cellDistY/2
+        univ_wcenterx = cells_conversion[0](3,3) + self.cellDistX
+        univ_wcentery = cells_conversion[1](3,3) + 3*self.cellDistY/2
         scale_x, scale_y = self.waferWidth/2, self.waferWidth/(2*self.c30)
         
         xcorners, ycorners = ([] for _ in range(2))
@@ -125,16 +148,17 @@ class GeometryData(BaseData):
         ypoint, y0, y1, y2, y3 = ({} for _ in range(5))
         xaxis, yaxis = ({} for _ in range(2))
 
-        # orientation 6
-        df['tc_x_center'] = (1.5*(df[self.cv]-df[self.cu])+0.5) * self.R
-        df['tc_y_center'] = (df[self.cv]+df[self.cu]-2*self.N+1) * self.r
+        df['tc_x_center'] = cells_conversion[0](df[self.cu],df[self.cv])
+        df['tc_y_center'] = cells_conversion[1](df[self.cu],df[self.cv])
         df['tc_x'] = df.wafer_shift_x + df['tc_x_center']
         df['tc_y'] = df.wafer_shift_y + df['tc_y_center']
         df['wx_center'] = df.wafer_shift_x + univ_wcenterx # fourth vertex (center) for cu/cv=(3,3)
         df['wy_center'] = df.wafer_shift_y + univ_wcentery # fourth vertex (center) for cu/cv=(3,3)
 
         df = self.cell_location(df)
-        
+        df = self.cell_location_shift(df)
+
+        angle = 0#5*np.pi/3 #CHANGE!!!!!!!!!        
         for kloc in ('UL', 'UR', 'B'):
             cx_d, cy_d = df[df.cloc==kloc]['tc_x'], df[df.cloc==kloc]['tc_y']
             wc_x, wc_y = df[df.cloc==kloc]['wx_center'], df[df.cloc==kloc]['wy_center']
@@ -144,41 +168,40 @@ class GeometryData(BaseData):
             # same for y0, y1, y2 and y3
             # tc positions refer to the center of the diamonds
             if kloc == 'UL':
-                x0.update({kloc: cx_d})
+                x0.update({kloc: cx_d - self.cellDistX/2})
             elif kloc == 'UR':
-                x0.update({kloc: cx_d})
+                x0.update({kloc: cx_d - self.cellDistX/2})
             else:
-                x0.update({kloc: cx_d - cellDistX})
+                x0.update({kloc: cx_d - self.cellDistX})
                 
-            x1.update({kloc: x0[kloc][:] + cellDistX})
+            x1.update({kloc: x0[kloc][:] + self.cellDistX})
             if kloc in ('UL', 'UR'):
                 x2.update({kloc: x1[kloc]})
                 x3.update({kloc: x0[kloc]})
             else:
-                x2.update({kloc: x1[kloc] + cellDistX})
+                x2.update({kloc: x1[kloc] + self.cellDistX})
                 x3.update({kloc: x1[kloc]})
 
             if kloc == 'UL':
-                y0.update({kloc: cy_d})
+                y0.update({kloc: cy_d - (self.cellDistY/2 + self.cellDistX*self.t30)})
             elif kloc == 'UR':
-                y0.update({kloc: cy_d})
+                y0.update({kloc: cy_d - (self.cellDistY/2)})
             else:
-                y0.update({kloc: cy_d + cellDistY})
+                y0.update({kloc: cy_d})
 
             if kloc in ('UR', 'B'):
-                y1.update({kloc: y0[kloc][:] - cellDistY})
+                y1.update({kloc: y0[kloc][:] - self.cellDistY})
             else:
-                y1.update({kloc: y0[kloc][:] + cellDistY})
+                y1.update({kloc: y0[kloc][:] + self.cellDistY})
             if kloc in ('B'):
                 y2.update({kloc: y0[kloc][:]})
             else:
-                y2.update({kloc: y1[kloc][:] + 2*cellDistY})
+                y2.update({kloc: y1[kloc][:] + 2*self.cellDistY})
             if kloc in ('UL', 'UR'):
-                y3.update({kloc: y0[kloc][:] + 2*cellDistY})
+                y3.update({kloc: y0[kloc][:] + 2*self.cellDistY})
             else:
-                y3.update({kloc: y0[kloc][:] + cellDistY})
+                y3.update({kloc: y0[kloc][:] + self.cellDistY})
 
-            angle = 5*np.pi/3
             x0[kloc], y0[kloc] = self.rotate(angle, x0[kloc], y0[kloc], wc_x, wc_y)
             x1[kloc], y1[kloc] = self.rotate(angle, x1[kloc], y1[kloc], wc_x, wc_y)
             x2[kloc], y2[kloc] = self.rotate(angle, x2[kloc], y2[kloc], wc_x, wc_y)
@@ -199,8 +222,8 @@ class GeometryData(BaseData):
             xaxis[kloc] = xaxis[kloc].drop(keys, axis=1)
             yaxis[kloc] = yaxis[kloc].drop(keys, axis=1)
 
-        df.loc[:, 'diamond_x'] = pd.concat(xaxis.values())
-        df.loc[:, 'diamond_y'] = pd.concat(yaxis.values())
+        df['diamond_x'] = pd.concat(xaxis.values())
+        df['diamond_y'] = pd.concat(yaxis.values())
             
         # define module corners' coordinates
         xcorners_str = ['corner1x','corner2x','corner3x','corner4x','corner5x','corner6x']
@@ -212,10 +235,10 @@ class GeometryData(BaseData):
         for i in range(len(ycorners)):
             df[ycorners_str[i]] = df.wafer_shift_y + ycorners[i]
 
-        df.loc[:, 'hex_x'] = df[xcorners_str].values.tolist()
-        df.loc[:, 'hex_x'] = df['hex_x'].map(lambda x: [[x]])
-        df.loc[:, 'hex_y'] = df[ycorners_str].values.tolist()
-        df.loc[:, 'hex_y'] = df['hex_y'].map(lambda x: [[x]])
+        df['hex_x'] = df[xcorners_str].values.tolist()
+        df['hex_x'] = df['hex_x'].map(lambda x: [[x]])
+        df['hex_y'] = df[ycorners_str].values.tolist()
+        df['hex_y'] = df['hex_y'].map(lambda x: [[x]])
         df = df.drop(xcorners_str + ycorners_str + ['tc_x_center', 'tc_y_center'], axis=1)
         return df
 

--- a/bye_splits/plot/display/main.py
+++ b/bye_splits/plot/display/main.py
@@ -39,7 +39,7 @@ with open(params.viz_kw['CfgProdPath'], 'r') as afile:
 with open(params.viz_kw['CfgDataPath'], 'r') as afile:
     cfg_data = yaml.safe_load(afile)
 
-data_part_opt = dict(tag='v2', reprocess=False, debug=True, logger=log)
+data_part_opt = dict(tag='mytag', reprocess=False, debug=True, logger=log)
 data_particle = {
     'photons': EventDataParticle(particles='photons', **data_part_opt),
     'electrons': EventDataParticle(particles='electrons', **data_part_opt)}
@@ -56,7 +56,10 @@ def common_props(p):
     # p.yaxis.visible = False
 
 def get_data(event, particles):
-    ds_geom = geom_data.provide(region='periphery')
+    region = None
+    if mode == event:
+        assert region is None
+    ds_geom = geom_data.provide(region=region)
 
     if mode=='ev':
         ds_ev = data_particle[particles].provide_event(event)
@@ -89,16 +92,27 @@ for k in (('photons', 'electrons') if mode=='ev' else ('Geometry',)):
                             'dropdown': bmd.Dropdown(label='Default Events', button_type='primary',
                                                     menu=def_ev_text[k], height=40)})
 
-def text_callback(attr, old, new, source, particles):
+def range_callback(fig, source, xvar, yvar):
+    """18 (centimeters) makes sures entire modules are always within the area shown"""
+    fig.x_range.start = min(source.data[xvar]-18)
+    fig.x_range.end = max(source.data[xvar]+18)
+    fig.y_range.start = min(source.data[yvar]-18)
+    fig.y_range.end = max(source.data[yvar]+18)
+
+def text_callback(attr, old, new, source, figs, particles):
     print('text callback ', particles, new)
     if not new.isdecimal():
         print('Wrong format!')
     else:
         source.data = get_data(int(new), particles)[mode]
+    for fig in figs:
+        range_callback(fig, source, 'tc_x', 'tc_y')
 
-def dropdown_callback(event, source, particles):
+def dropdown_callback(event, source, figs, particles):
     print('dropdown callback', particles, int(event.__dict__['item']))
     source.data = get_data(int(event.__dict__['item']), particles)[mode]
+    for fig in figs:
+        range_callback(fig, source, 'tc_x', 'tc_y')
 
 def display():
     doc = curdoc()
@@ -136,7 +150,7 @@ def display():
            """)
 
         if mode == 'ev':
-            sld_en = bmd.Slider(start=cfg_prod['mipThreshold'], end=5,
+            sld_en = bmd.Slider(start=0, end=5, #cfg_prod['mipThreshold']
                                 value=cfg_prod['mipThreshold'], step=0.1,
                                 title='Energy threshold [mip]', **sld_opt)
             sld_en_cb = bmd.CustomJS(args=dict(s=vsrc), code="""s.change.emit();""")
@@ -186,7 +200,6 @@ def display():
         for elem in zip(*zip_obj):
             if mode == 'ev' and elem[2] < cfg_prod['mipThreshold']: #cut replicates the default `view_en`
                 continue
-            #breakpoint()
             if max(elem[0][0][0]) > cur_xmax: cur_xmax = max(elem[0][0][0])
             if min(elem[0][0][0]) < cur_xmin: cur_xmin = min(elem[0][0][0])
             if max(elem[1][0][0]) > cur_ymax: cur_ymax = max(elem[1][0][0])
@@ -214,7 +227,8 @@ def display():
             x_range=bmd.Range1d(cur_xmin, cur_xmax), y_range=bmd.Range1d(cur_ymin, cur_ymax),
             **fig_opt)
         p_mods = figure(
-            x_range=p_diams.x_range, y_range=p_diams.y_range,
+            #x_range=p_diams.x_range, y_range=p_diams.y_range,
+            x_range=bmd.Range1d(-200, 200), y_range=bmd.Range1d(-200, 200),
             **fig_opt)
 
         if mode == 'ev':
@@ -270,9 +284,14 @@ def display():
 
             p_diams.add_layout(cbar_diams, 'right')
             p_mods.add_layout(cbar_mods, 'right')
+            # p_diams.x_range.callback = bmd.CustomJS(args=dict(xrange=myplot.x_range), code="""
+            # xrange.set({"start": 10, "end": 20})
+            # """)
 
-            elements[ksrc]['textinput'].on_change('value', partial(text_callback, source=vsrc, particles=ksrc))
-            elements[ksrc]['dropdown'].on_event('menu_item_click', partial(dropdown_callback, source=vsrc, particles=ksrc))
+            elements[ksrc]['textinput'].on_change('value', partial(text_callback, source=vsrc,
+                                                                   figs=(p_diams, p_mods), particles=ksrc))           
+            elements[ksrc]['dropdown'].on_event('menu_item_click', partial(dropdown_callback, source=vsrc,
+                                                                           figs=(p_diams,p_mods), particles=ksrc))
 
         ####### (x,y) plots ################################################################
         # p_xy = figure(width=width, height=height,


### PR DESCRIPTION
Align the position of trigger cell and display elements in real data units (centimeters). Due to the diamond shaped visualization of trigger cells and to geometry-related shifts, it is not possible to perfectly align the center of each visualized trigger cell with its true center. Below we show two approaches:

- perfectly aligned diamond-shaped trigger cells within a hexagonal module
- sligthly mis-aligned module "thirds", being however closer to truth trigger cell position

As for the figure legends (cartesian units in centimeters):

- in blue one can see the position of the trigger cells after a coordinate conversion from (U,V) to (X,Y); ```tc_x``` and ```tc_y``` in the code
- in orange we show the true trigger cell position; ```x``` and ```y``` in the code

In the code one can add the shift by including the ```cell_location_shift``` method of the ```Geometry``` class in ```bye_splits/data_handle/geometry.py```.

![fig1](https://user-images.githubusercontent.com/20703947/214052364-5904610b-5e26-4b9c-83d8-27dc5880839b.svg)

![fig2](https://user-images.githubusercontent.com/20703947/214052428-14d13a8a-476e-46b1-af46-16ccbe62702d.svg)

It has been decided to use the second method because, though less appealing visually, gives a better approximation of what the detector "sees".

This PR includes in addition automatically updated figure ranges upon selecting a new event.