### PR TITLE
Command line options with boost

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,10 @@ CCFLAGS  := $(CXXFLAGS)
 
 ROOT_LIBS := $(shell root-config --cflags --ldflags --libs --glibs --auxlibs --auxcflags)
 ROOT_LIBS_EXTRA := -lMinuit -lrt -lCore -lROOTDataFrame
+BOOSTFLAGS := -lboost_program_options
 ROOTFLAGS := $(ROOT_LIBS) -L $(ROOTSYS)/lib $(ROOT_LIBS_EXTRA)
 YAMLFLAGS := -L $(BASEDIR)/yaml-cpp-yaml-cpp-0.7.0/build/ -lyaml-cpp
-######BOOSTFLAGS := -lboost_program_options
-EXTRAFLAGS := $(ROOTFLAGS) $(YAMLFLAGS)
+EXTRAFLAGS := $(ROOTFLAGS) $(YAMLFLAGS) $(BOOSTFLAGS)
 
 SRCS := $(BUILDIR)/$(basename /$(EXEC)).cc \
 	$(wildcard $(SRCDIR)/*.cc)

--- a/bye_splits/production/include/skim.h
+++ b/bye_splits/production/include/skim.h
@@ -12,9 +12,12 @@
 
 #include "yaml-cpp/yaml.h"
 
+#include <boost/program_options.hpp>
+namespace po = boost::program_options;
+
 using namespace std;
 
-void skim(string, string, string, string);
+void skim(string, string, string, string, int);
 
 template <class U>
 auto internal_join_vars(vector<U>& dest, const vector<U>& vec) -> void {

--- a/bye_splits/production/prod_params.yaml
+++ b/bye_splits/production/prod_params.yaml
@@ -1,4 +1,12 @@
-disconnectedTriggerLayers: [2,4,6,8,10,12,14,16,18,20,22,24,26,28]
-reachedEE: 2
-deltarThreshold: 0.05
-mipThreshold: 0.5
+io:
+    dir: FloatingpointMixedbcstcrealsig4DummyHistomaxxydr015GenmatchGenclustersntuple
+    tree: HGCalTriggerNtuple
+
+selection:
+    disconnectedTriggerLayers: [2,4,6,8,10,12,14,16,18,20,22,24,26,28]
+    reachedEE: 2
+    deltarThreshold: 0.05
+    mipThreshold: 0.5
+
+###    dir: hgcalTriggerNtuplizer
+###    tree: HGCalTriggerNtuple

--- a/bye_splits/production/produce.cc
+++ b/bye_splits/production/produce.cc
@@ -24,20 +24,71 @@ int convert_to_int(char** argv, int idx) {
   return arg_int;
 }
 
+void show_help(const po::options_description&, const std::string&);
+po::variables_map process_program_options(int argc, char **argv);
+
+void validate(po::variables_map args) {
+  std::string particles = args["particles"].as<string>();
+  if(!(particles=="photons" || particles=="electrons" || particles=="pions")) {
+    throw po::validation_error(po::validation_error::invalid_option_value, "particles");
+  }
+}
+
+void show_help(const po::options_description& desc,
+			   const std::string& topic = "") {
+  std::cout << desc << '\n';
+  if (topic != "") {
+	std::cout << "You asked for help on: " << topic << '\n';
+  }
+}
+
+po::variables_map process_program_options(int argc, char **argv)
+{
+  po::options_description desc("Usage");
+  desc.add_options()
+	("help,h",
+	 po::value<string>()->implicit_value("")
+	 ->notifier([&desc](const std::string &topic) {show_help(desc, topic);}),
+	 "Show help. If given, show help on the specified topic.")
+	("nevents", po::value<int>()->default_value(-1),
+	 "number of entries to consider, useful for debugging (-1 means all)")
+	("particles", po::value<string>()->required(),
+	 "type of particle");
+  
+  if (argc <= 1) {
+	show_help(desc); // does not return
+	exit( EXIT_SUCCESS );
+  }
+
+  po::variables_map args;
+  try {
+	po::store(po::parse_command_line(argc, argv, desc), args);
+  }
+  catch (po::error const& e) {
+	std::cerr << e.what() << '\n';
+	exit( EXIT_FAILURE );
+  }
+  po::notify(args);
+  validate(args);
+  return args;
+}
+
 //Run with ./produce.exe photons
 int main(int argc, char **argv) {
   std::string dir = "/eos/user/b/bfontana/FPGAs/new_algos/";
   std::string tree_name = "FloatingpointMixedbcstcrealsig4DummyHistomaxxydr015GenmatchGenclustersntuple/HGCalTriggerNtuple";
 
-  if (strlen(argv[1]) == 0) {
-	return 1; // empty string
+  po::variables_map args = process_program_options(argc, argv);
+  if (args.count("help")) {
+    return 1;
   }
 
-  //process_program_options(argc, argv);
-  string particle = std::string(argv[1]);
+  string particles = args["particles"].as<string>();
+  int nevents = args["nevents"].as<int>();
 
-  std::string infile = particle + "_0PU_bc_stc_hadd.root";
-  std::string outfile = "skim_small_" + infile;
-  skim(tree_name, dir + infile, dir + outfile, particle);
+  std::string infile = particles + "_0PU_bc_stc_hadd.root";
+  std::string events_str = nevents > 0 ? std::to_string(nevents) + "events_" : "";
+  std::string outfile = "skim_" + events_str + infile;
+  skim(tree_name, dir + infile, dir + outfile, particles, nevents);
   return 0;
 }

--- a/bye_splits/production/src/skim.cc
+++ b/bye_splits/production/src/skim.cc
@@ -2,7 +2,6 @@
 
 ROOT::VecOps::RVec<float> calcDeltaR(ROOT::VecOps::RVec<float> geta, ROOT::VecOps::RVec<float> gphi,
 									 ROOT::VecOps::RVec<float> cleta,  ROOT::VecOps::RVec<float> clphi)
-  
 {
   if(geta.size()==0) // empty event (filtered before)
 	return ROOT::VecOps::RVec<float>();
@@ -22,68 +21,92 @@ ROOT::VecOps::RVec<float> calcDeltaR(ROOT::VecOps::RVec<float> geta, ROOT::VecOp
   return deltaR;
 }
 
-void skim(string tn, string inf, string outf, string particle) {
+ROOT::RDF::RResultPtr<long long unsigned> addProgressBar(ROOT::RDF::RNode df) {
+  auto c = df.Count();
+  c.OnPartialResult(/*every=*/100,
+					[] (long long unsigned e) { cout << "Progress: " << e << endl; });
+  return c;
+}
+
+void skim(string tn, string inf, string outf, string particle, int nevents) {
 
   // read input parameters
   YAML::Node config = YAML::LoadFile("bye_splits/production/prod_params.yaml");
   vector<int> discLayers;
-  if (config["disconnectedTriggerLayers"]) {
-	discLayers = config["disconnectedTriggerLayers"].as<vector<int>>();
+  if (config["selection"]["disconnectedTriggerLayers"]) {
+	discLayers = config["selection"]["disconnectedTriggerLayers"].as<vector<int>>();
   }
   string reachedEE="", deltarThreshold="", mipThreshold="";
-  if (config["reachedEE"]) reachedEE = config["reachedEE"].as<string>();
-  if (config["deltarThreshold"]) deltarThreshold = config["deltarThreshold"].as<string>();
-  if (config["mipThreshold"]) mipThreshold = config["mipThreshold"].as<string>();
-
+  if (config["selection"]["reachedEE"])
+	reachedEE = config["selection"]["reachedEE"].as<string>();
+  if (config["selection"]["deltarThreshold"])
+	deltarThreshold = config["selection"]["deltarThreshold"].as<string>();
+  if (config["selection"]["mipThreshold"])
+	mipThreshold = config["selection"]["mipThreshold"].as<string>();
   // variables
   string vtmp = "tmp_good";
   
-  //ROOT::EnableImplicitMT();
+  if(nevents==-1) { //RDataFrame.Range() does not work with multithreading
+	ROOT::EnableImplicitMT();
+	cout << "Multithreaded..." << endl;
+  }
   ROOT::RDataFrame dataframe(tn, inf);
-  auto df = dataframe.Range(0, 500);
-
+  
   // gen-related variables
-  vector<string> genvars_int = {"genpart_pid"};
-  vector<string> genvars_float = {"genpart_exphi", "genpart_exeta", "genpart_energy"};
-  vector<string> genvars = join_vars(genvars_int, genvars_float);
+  vector<string> gen_intv = {"genpart_pid"};
+  vector<string> gen_floatv = {"genpart_exphi", "genpart_exeta", "genpart_energy"};
+  vector<string> gen_floatv2 = {"genpart_posx", "genpart_posy", "genpart_posz"};
+  vector<string> gen_v = join_vars(gen_intv, gen_floatv, gen_floatv2);
 
   // selection on generated particles (within each event)
-  unordered_map<string,string> pmap = {{"photons", "22"},
-									   {"electrons", "11"}};
+  unordered_map<string,string> pmap = {
+	{"photons", "22"},
+	{"electrons", "11"},
+	{"pions", "211"}};
   string condgen = "genpart_gen != -1 && ";
   condgen += "genpart_reachedEE == " + reachedEE;
-  condgen += " && genpart_pid == " + pmap[particle];
+  condgen += " && genpart_pid == abs(" + pmap[particle] + ")";
   condgen += " && genpart_exeta > 0";
 
-  df = df.Define(vtmp + "_gens", condgen);
-  for(auto& v : genvars)
-   	df = df.Define(vtmp + "_" + v, v + "[" + vtmp + "_gens]");
+  auto df = dataframe.Define(vtmp + "_gens", condgen);
+  for(auto& v : gen_v) { df = df.Define(vtmp + "_" + v, v + "[" + vtmp + "_gens]"); }
 
   //remove events with zero generated particles
   auto dfilt = df.Filter(vtmp + "_genpart_pid.size()!=0");
 
   // trigger cells-related variables
-  vector<string> tcvars_uint = {"tc_cluster_id"};
-  vector<string> tcvars_int = {"tc_layer", "tc_cellu", "tc_cellv", "tc_waferu", "tc_waferv"};
-  vector<string> tcvars_float = {"tc_energy", "tc_mipPt", "tc_pt", 
-								 "tc_x", "tc_y", "tc_z", "tc_phi", "tc_eta"};
+  vector<string> tc_uintv = {"tc_cluster_id"};
+  vector<string> tc_intv = {"tc_layer", "tc_cellu", "tc_cellv", "tc_waferu", "tc_waferv"};
+  vector<string> tc_floatv = {"tc_energy", "tc_mipPt", "tc_pt", 
+							  "tc_x", "tc_y", "tc_z", "tc_phi", "tc_eta"};
 
   // selection on trigger cells (within each event)
-  vector<string> tcvars = join_vars(tcvars_uint, tcvars_int, tcvars_float);
-  string condtc = "tc_zside == 1 && tc_mipPt > " + mipThreshold;// && tc_layer%2 == 0";
+  vector<string> tc_v = join_vars(tc_uintv, tc_intv, tc_floatv);
+  string condtc = "tc_zside == 1 && tc_mipPt > " + mipThreshold + " && tc_layer <= 28";
   auto dd1 = dfilt.Define(vtmp + "_tcs", condtc);
-  for(auto& v : tcvars)
+  for(auto& v : tc_v)
 	dd1 = dd1.Define(vtmp + "_" + v, v + "[" + vtmp + "_tcs]");
 
+  // // module sums-related variables
+  // vector<string> tsum_intv = {"ts_layer", "ts_waferu", "ts_waferv"};
+  // vector<string> tsum_floatv = {"ts_energy", "ts_mipPt", "ts_pt"};
+  // vector<string> tsum_v = join_vars(tsum_intv, tsum_floatv);
+  
+  // // selection on module trigger sums (within each event)
+  // string condtsum = "ts_zside == 1 && ts_mipPt > " + mipThreshold;
+  // dd1 = dd1.Define(vtmp + "_tsum", condtsum);
+  // for(auto& v : tsum_v)
+  // 	dd1 = dd1.Define(vtmp + "_" + v, v + "[" + vtmp + "_tsum]");
+
   // cluster-related variables
-  vector<string> clvars_uint = {"cl3d_id"};
-  vector<string> clvars_float = {"cl3d_energy", "cl3d_pt", "cl3d_eta", "cl3d_phi"};
-  vector<string> clvars = join_vars(clvars_uint, clvars_float);
+  vector<string> cl_uintv = {"cl3d_id"};
+  vector<string> cl_floatv = {"cl3d_energy", "cl3d_pt", "cl3d_eta", "cl3d_phi"};
+  vector<string> cl_v = join_vars(cl_uintv, cl_floatv);
 
   // selection on clusters (within each event)
   string condcl = "cl3d_eta > 0";
   dd1 = dd1.Define(vtmp + "_cl", condcl);
-  for(auto& v : clvars)
+  for(auto& v : cl_v)
 	dd1 = dd1.Define(vtmp + "_" + v, v + "[" + vtmp + "_cl]");
 
   //remove events with zero clusters
@@ -97,38 +120,62 @@ void skim(string tn, string inf, string outf, string particle) {
 	.Define(matchvars[1], cond_deltaR);
 
   // convert root vector types to vector equivalents (uproot friendly)
-  vector<string> intvars = join_vars(genvars_int, tcvars_int);
-  for(auto& var : intvars) {
+  // vector<string> intv = join_vars(gen_intv, tc_intv, tsum_intv);
+  vector<string> intv = join_vars(gen_intv, tc_intv);
+  for(auto& var : intv) {
 	dd2 = dd2.Define("good_" + var,
 					 [](const ROOT::VecOps::RVec<int> &v) {
 					   return vector<int>(v.begin(), v.end());
 					 },
 					 {vtmp + "_" + var});
   }
-  vector<string> uintvars = join_vars(clvars_uint, tcvars_uint);
-  for(auto& var : uintvars) {
+  vector<string> uintv = join_vars(cl_uintv, tc_uintv);
+  for(auto& var : uintv) {
     dd2 = dd2.Define("good_" + var,
 					 [](const ROOT::VecOps::RVec<unsigned> &v) {
 					   return vector<unsigned>(v.begin(), v.end());
 					 },
 					 {vtmp + "_" + var});
   }
-  vector<string> floatvars = join_vars(genvars_float, tcvars_float, clvars_float);
-  for(auto& var : floatvars) {
+  //vector<string> floatv = join_vars(gen_floatv, tc_floatv, cl_floatv, tsum_floatv);
+  vector<string> floatv = join_vars(gen_floatv, tc_floatv, cl_floatv);
+  for(auto& var : floatv) {
 	dd2 = dd2.Define("good_" + var,
 					 [](const ROOT::VecOps::RVec<float> &v) {
 					   return vector<float>(v.begin(), v.end());
 					 },
 					 {vtmp + "_" + var});
   }
+  vector<string> floatv2 = join_vars(gen_floatv2);
+  for(auto& var : floatv2) {
+	dd2 = dd2.Define("good_" + var,
+					 [](const ROOT::VecOps::RVec<vector<float>> &v) {
+					   vector<vector<float>> vec(v.size());
+					   for(unsigned i=0; i<v.size(); ++i) {
+						 vec[i] = vector<float>(v[i].begin(), v[i].end());
+					   }
+					   return vec;
+					 },
+					 {vtmp + "_" + var});
+  }
   
   // define stored variables (and rename some)
-  vector<string> allvars = join_vars(genvars, tcvars, clvars);
+  // vector<string> allvars = join_vars(gen_v, tc_v, cl_v, tsum_v);
+  vector<string> allvars = join_vars(gen_v, tc_v, cl_v);
   vector<string> good_allvars = {"event"};
   good_allvars.insert(good_allvars.end(), matchvars.begin(), matchvars.end());
   for(auto& v : allvars)
 	good_allvars.push_back("good_" + v);
 
   // store skimmed file
-  dd2.Snapshot(tn, outf, good_allvars);
+  if(nevents>0) {
+	dd2.Range(0, nevents).Snapshot(tn, outf, good_allvars);
+  }
+  else {
+	dd2.Snapshot(tn, outf, good_allvars);
+  }
+  
+  // display event processing progress
+  ROOT::RDF::RResultPtr<long long unsigned> count = addProgressBar(ROOT::RDF::RNode(dd2));
+  count.GetValue();
 }


### PR DESCRIPTION
Add command line options mechanism for skim production via ```bost_program_options```. To run the skim one now runs (after compilation):


```shell
make
./produce.exe --particles photons --nevents 500
```

Adding ```--help``` prints the meaning of each argument and exits.

_Disclaimer for CMSSW users:_ ```bost_program_options``` does not work well with the ```cmsenv``` command, leading to "undefined references".