### PR TITLE
Solve out-of-scope bug

### DIFF
--- a/bye_splits/tasks/smooth.py
+++ b/bye_splits/tasks/smooth.py
@@ -70,11 +70,11 @@ def smoothAlongPhi(arr, kernel,
         area = (1 + 2.0 * (1 - 0.5**nBinsSide)) # one element per Rz bin
     elif kernel=='flat_top':
         area = 5 - 2**(2-nBinsSide) # 1 + 1 + 1 + 2*(Sum[1/(2^i), {i, 1, nBinsSide - 1}])
-        
+
     if seedsNormByArea:
-        R1 = minROverZ + bin1 * (maxROverZ - minROverZ) / nbinsRz
+        R1 = minROverZ + np.arange(nbinsRz) * (maxROverZ - minROverZ) / nbinsRz
         R2 = R1 + ((maxROverZ - minROverZ) / nbinsRz)
-        area = area * ((np.pi * (R2**2 - R1**2)) / nbinsPhi);
+        area *= ((np.pi * (R2**2 - R1**2)) / nbinsPhi);
     else:
         #compute quantities for non-normalised-by-area histoMax
         #The 0.1 factor in bin1_10pct is an attempt to keep the same rough scale for seeds.


### PR DESCRIPTION
Adresses #13. 
The issue arises from the [original CMSSW code](https://github.com/bfonta/bye_splits/blob/06197ca2d3a76add9538f6f83f23b511e4c17569/bye_splits/tasks/smooth.py#L75), including a loop on ```bin1``` which is here instead done with a ```numpy``` broadcast. 
Note tested (but no impact expected given the number of lines changed and the current default ```seedsNormByArea=False```). Intense testing planned when adressing #15.