### PR TITLE
Bugfix: set seed only when requested

### DIFF
--- a/bye_splits/data_handle/event.py
+++ b/bye_splits/data_handle/event.py
@@ -33,6 +33,7 @@ class EventData(BaseData):
             self.cache_events(self.events)
 
         self.ev_numbers = self._get_event_numbers()
+        self.rng = np.random.default_rng()
 
     def _add_events(self, events):
         events = self._convert_to_list(events)
@@ -66,7 +67,7 @@ class EventData(BaseData):
         if not isinstance(events, (tuple,list)):
             ret = [events]
         return ret
-        
+
     def _event_mask(self, ds, events):
         """Select 'events' from awkward dataset 'ds'."""
         #evmask = False
@@ -137,14 +138,15 @@ class EventData(BaseData):
 
         return ret
     
-    def provide_random_event(self, seed, merge=False):
+    def provide_random_event(self, seed=None):
         """Provide a random event"""
-        return self.provide_random_events(n=1, seed=seed, merge=merge)
+        return self.provide_random_events(n=1, seed=seed)
 
-    def provide_random_events(self, n, seed, merge=False):
+    def provide_random_events(self, n, seed=None):
         """Provide 'n' random events."""
-        np.random.seed(seed)
-        events = np.random.choice(self.ev_numbers, size=n, replace=False)
+        if seed is not None:
+            self.rng = np.random.default_rng(seed=seed)
+        events = self.rng.choice(self.ev_numbers, size=n, replace=False)
         return self.provide_events(events), events
         
     def select(self):

--- a/bye_splits/data_handle/event.py
+++ b/bye_splits/data_handle/event.py
@@ -137,11 +137,11 @@ class EventData(BaseData):
 
         return ret
     
-    def provide_random_event(self, seed, merge):
+    def provide_random_event(self, seed, merge=False):
         """Provide a random event"""
         return self.provide_random_events(n=1, seed=seed, merge=merge)
 
-    def provide_random_events(self, n, seed, merge):
+    def provide_random_events(self, n, seed, merge=False):
         """Provide 'n' random events."""
         np.random.seed(seed)
         events = np.random.choice(self.ev_numbers, size=n, replace=False)
@@ -153,7 +153,6 @@ class EventData(BaseData):
             allvars = set([y for x in self.var.values() for y in x.values()])
             data = tree.arrays(filter_name='/' + '|'.join(allvars) + '/',
                                library='ak')
-
         # data[self.var.v] = data.waferv
         # data[self.newvar.vs] = -1 * data.waferv
         # data[self.newvar.c] = "#8a2be2"


### PR DESCRIPTION
**Description**

Random seed issue described in #24. This PR also fixes a simple bug introduced in #18, and changes the structure of ```EventDataParticle``` for clarity.

**Changes**

- *Random seed*

The seed is now set only when required by the user by either ```provide_random_event()``` or ```provide_random_events()```. Now using the recommended ```np.random.default_rng()``` instead of ```np.random.seed()``` (avoids the definition of global variables). Note that a new instance of the generator has to be created every time a seed is requested and ```Generator.random.choice()``` is used, since otherwise the *sequence* of numbers will be the same, but the individual numbers will not. Example follows (script called ```test.py```):

```python
import numpy                                                                                                                                
rng = numpy.random.default_rng(0)                                                                                                           
for _ in range(3):                                                                                                                          
    out = [rng.choice([0, 1], p=[0.5, 0.5]) for _ in range(10)]                                                                             
    print(out)
```

```shell
$ python test.py
[1, 0, 0, 0, 1, 1, 1, 1, 1, 1]
[1, 0, 1, 0, 1, 0, 1, 1, 0, 0]
[0, 0, 1, 1, 1, 0, 1, 1, 1, 1]
$ python test.py
[1, 0, 0, 0, 1, 1, 1, 1, 1, 1]
[1, 0, 1, 0, 1, 0, 1, 1, 0, 0]
[0, 0, 1, 1, 1, 0, 1, 1, 1, 1]
```

```python
import numpy
for _ in range(3):
    rng = numpy.random.default_rng(0)
    out = [rng.choice([0, 1], p=[0.5, 0.5]) for _ in range(10)]
    print(out)
```

```shell
$ python test.py
[1, 0, 0, 0, 1, 1, 1, 1, 1, 1]
[1, 0, 0, 0, 1, 1, 1, 1, 1, 1]
[1, 0, 0, 0, 1, 1, 1, 1, 1, 1]
$ python test.py
[1, 0, 0, 0, 1, 1, 1, 1, 1, 1]
[1, 0, 0, 0, 1, 1, 1, 1, 1, 1]
[1, 0, 0, 0, 1, 1, 1, 1, 1, 1]

```

- *Bug*

Introduced after implementing [this comment](https://github.com/bfonta/bye_splits/pull/18#discussion_r1122914823) in #18. After changing the order, ```keys()``` must be used instead of ```values()```.

- *Class factory*

```EventDataParticle``` is currently a class, using composition to interface ```EventData``` for different particles. This PR converts it to a class factory function, more appropriate to its role. Backward compatible.