### PR TITLE
Full ROI Chain

### DIFF
--- a/bye_splits/data_handle/data_process.py
+++ b/bye_splits/data_handle/data_process.py
@@ -25,7 +25,7 @@ def baseline_selection(df_gen, df_cl, sel, **kw):
     data = data[(data.gen_eta>kw['EtaMin']) & (data.gen_eta<kw['EtaMax'])]
     
     if sel.startswith('above_eta_'):
-        data = data[df.gen_eta > float(sel.split('above_eta_')[1])]
+        data = data[data.gen_eta > float(sel.split('above_eta_')[1])]
         return data
     
     with common.SupressSettingWithCopyWarning():

--- a/bye_splits/plot/display/main.py
+++ b/bye_splits/plot/display/main.py
@@ -31,7 +31,7 @@ settings.ico_path = 'none'
 import utils
 from utils import params, common, parsing
 import data_handle
-from data_handle.data_handle import EventDataParticle
+from data_handle.data_process import EventDataParticle
 from data_handle.geometry import GeometryData
 
 def common_props(p):

--- a/bye_splits/plot/roi_chain_plotter.py
+++ b/bye_splits/plot/roi_chain_plotter.py
@@ -10,27 +10,40 @@ sys.path.insert(0, parent_dir)
 import utils
 from utils import common, params, parsing
 
+import yaml
 import argparse
 import numpy as np
 import pandas as pd
 import bokeh
 from bokeh import models as bmd
 
-def common_props(fig):
+def common_props(fig, legend=True):
     fig.output_backend = 'svg'
     fig.toolbar.logo = None
-    fig.legend.click_policy='hide'
-    fig.legend.location = 'top_left'
-    fig.legend.label_text_font_size = '8pt'
+    if legend:
+        fig.legend.click_policy='hide'
+        fig.legend.location = 'bottom_right'
+        fig.legend.label_text_font_size = '8pt'
     fig.min_border_bottom = 5
     fig.xaxis.visible = True
 
+def get_folder_plots():
+    with open(params.CfgPath, 'r') as afile:
+        cfg = yaml.safe_load(afile)
+    if cfg['cluster']['ROICylinder']:
+        folder = 'CylinderOnly'
+    else:
+        folder = 'AllTCs'
+    return folder
+
 def resolution_plotter(df, pars, user):
-    out = common.fill_path(os.path.join('/eos/user', user[0], user, 'www/L1/res'),
-                           ext='html', **pars)
+    folder = get_folder_plots()
+    folder = os.path.join('/eos/user', user[0], user, 'www/L1/', folder)
+    common.create_dir(folder)
+    out = common.fill_path(os.path.join(folder, 'res'), ext='html', **pars)
     bokeh.io.output_file(out)
     
-    nbeta, nbphi, nben = (13 for _ in range(3))
+    nbeta, nbphi, nben = (10 for _ in range(3))
     bins = {'eta': np.linspace(df.geneta.min(), df.geneta.max(), nbeta+1),
             'phi': np.linspace(df.genphi.min(), df.genphi.max(), nbphi+1),
             'en': np.linspace(df.genen.min(), df.genen.max(), nben+1)}
@@ -41,52 +54,49 @@ def resolution_plotter(df, pars, user):
     def q3(x):
         return x.quantile(0.84135)
 
-    avars = ['resroi', 'rescl']
-    values = {x:df.groupby(pd.cut(df[x], bins[x])).agg(['median', q1, q3])[avars+'en']
+    avars = ['rescl']  #avars = ['resroi', 'rescl']
+    values = {x:df.groupby(pd.cut(df['gen'+x], bins[x])).agg(['median', q1, q3, 'size'])[[k+'en' for k in avars]]
               for x in bins.keys()}
     labels = {'eta': '\u03B7',
               'phi': '\u03C6',
               'en': 'Energy [GeV]'}
     
     figs = {x:None for x in bins.keys()}
-    dvar = {'resroi': ('ROI Energy Resolution', 'ROI', 'blue'),
+    dvar = {'resroi': ('TCs Energy Resolution', 'TCs', 'blue'),
             'rescl': ('Cluster Enenergy Resolution', 'Clusters', 'red')}
     wshifts = {'eta': {'resroi': -0.01, 'rescl': 0.01},
                'phi': {'resroi': -0.1, 'rescl': 0.01},
                'en':  {'resroi': -10, 'rescl': 10}}
 
-    for binvar in bins.keys():
-        hshift = (bins[binvar][1]-bins[binvar][0])/2
-        vshift = 0.1
-        ymax = np.array(values[binvar]['resroi']['q3']).max()
-        ymin = np.array(values[binvar]['rescl']['q1']).min()
-        figs[binvar] = bokeh.plotting.figure(
-            width=600, height=300, title='', tools='save',
-            x_range=(bins[binvar][0], bins[binvar][-1]+4*hshift),
-            #y_range=(ymin-vshift, ymax+vshift),
-            y_range=(-0.52, 0.02),
+    for bk in bins.keys():
+        hshift = (bins[bk][1]-bins[bk][0])/2
+        ymax = max([np.array(values[bk][x+'en']['q3']).max() for x in avars])
+        ymin = min([np.array(values[bk][x+'en']['q1']).min() for x in avars])
+        figs[bk] = bokeh.plotting.figure(
+            width=600, height=300, title='', tools='box_zoom,reset,pan,save',
+            x_range=(bins[bk][0], bins[bk][-1]+hshift),
+            y_range=(-0.26, 0.02),
             y_axis_type='linear'
         )
 
         for avar in avars:
-            bincenters = (bins[binvar][:-1]+bins[binvar][1:])/2
-            opt = dict(x=bincenters+wshifts[binvar][avar],
+            bincenters = (bins[bk][:-1]+bins[bk][1:])/2
+            opt = dict(x=bincenters+wshifts[bk][avar],
                        legend_label=dvar[avar][1],
                        color=dvar[avar][2])
-
-            median = list(values[binvar][avar]['median'])
-            q1 = np.array(values[binvar][avar]['q1'])
-            q3 = np.array(values[binvar][avar]['q3'])
+            median = list(values[bk][avar+'en']['median'])
+            q1 = np.array(values[bk][avar+'en']['q1'])
+            q3 = np.array(values[bk][avar+'en']['q3'])
             medianopt = dict(y=median)
 
             # median
-            figs[binvar].square(size=8, **medianopt, **opt)
-            figs[binvar].line(line_width=1, **medianopt, **opt)
-            figs[binvar].line(x=[bincenters[0]-hshift, bincenters[-1]+4*hshift], y=[0.,0.],
+            figs[bk].square(size=8, **medianopt, **opt)
+            figs[bk].line(line_width=1, **medianopt, **opt)
+            figs[bk].line(x=[bincenters[0]-hshift, bincenters[-1]+hshift], y=[0.,0.],
                               line_width=1, line_dash='dashed', color='gray')
 
             # quantiles
-            source = bmd.ColumnDataSource(data=dict(base=bincenters + wshifts[binvar][avar],
+            source = bmd.ColumnDataSource(data=dict(base=bincenters + wshifts[bk][avar],
                                                     q3=q3, q1=q1))
             quant = bmd.Whisker(base='base', upper='q3', lower='q1', source=source,
                                 level='annotation', line_width=2, line_color=dvar[avar][2])
@@ -94,11 +104,11 @@ def resolution_plotter(df, pars, user):
             quant.lower_head.size=10
             quant.upper_head.line_color = dvar[avar][2]
             quant.lower_head.line_color = dvar[avar][2]
-            figs[binvar].add_layout(quant)
+            figs[bk].add_layout(quant)
 
-            figs[binvar].xaxis.axis_label = labels[binvar]
-            figs[binvar].yaxis.axis_label = r'$$E/E_{Gen}-1$$'
-            common_props(figs[binvar])
+            figs[bk].xaxis.axis_label = labels[bk]
+            figs[bk].yaxis.axis_label = r'$$E/E_{Gen}-1$$'
+            common_props(figs[bk])
             
     if pars.sel.startswith('above_eta_'):
         title_suf = ' (eta > ' + pars.selection.split('above_eta_')[1] + ')'
@@ -119,15 +129,167 @@ def resolution_plotter(df, pars, user):
 
     return None
 
-def distribution_plotter(df, pars, user):
-    out = common.fill_path(os.path.join('/eos/user', user[0], user, 'www/L1/dist'),
+def seed_plotter(df, pars, user):
+    with open(params.CfgPath, 'r') as afile:
+        cfg = yaml.safe_load(afile)
+
+    extra_name = '_hexdist' if cfg['seed_roi']['hexDist'] else ''
+    out = common.fill_path(os.path.join('/eos/user', user[0], user,
+                                        'www/L1/seed'+ extra_name),
                            ext='html', **pars)
+    bokeh.io.output_file(out)
+
+    # required to calculate the seeding efficiency
+    df['has_seeds'] = (df.nseeds > 0).astype(int)
+    df['less_seeds'] = (df.nseeds < df.nrois).astype(int)
+
+    nbeta, nbphi, nben = (10 for _ in range(3))
+    bins = {'eta': np.linspace(df.geneta.min(), df.geneta.max(), nbeta+1),
+            'phi': np.linspace(df.genphi.min(), df.genphi.max(), nbphi+1),
+            'en': np.linspace(df.genen.min(), df.genen.max(), nben+1)}
+
+    def q1(x):
+        return x.quantile(0.15865)
+
+    def q3(x):
+        return x.quantile(0.84135)
+
+    avars = ['nseeds', 'nrois', 'has_seeds', 'less_seeds']
+    values = {x:df.groupby(pd.cut(df['gen'+x], bins[x])).agg(['median', 'mean', 'std', q1, q3, 'sum', 'size'])[avars]
+              for x in bins.keys()}
+    labels = {'eta': '\u03B7',
+              'phi': '\u03C6',
+              'en': 'Energy [GeV]'}
+
+    fcounts, feff  = ({x:None for x in bins.keys()} for _ in range(2))
+    dvar = {'nseeds': ('Number of seeds', '#seeds', 'blue'),
+            'nrois': ('Number of ROIs', '#ROIs', 'red')}
+    wshifts = {'eta': [-0.01,0.,0.01],
+               'phi': [-0.1,0.,0.01],
+               'en': [-10,0,10]}
+
+    # efficiencies need a separate treatment
+    avars.remove('has_seeds')
+    avars.remove('less_seeds')
+
+    # plot ROI and seed multiplicities
+    for binvar in bins.keys():
+        hshift = (bins[binvar][1]-bins[binvar][0])/2
+        fcounts[binvar] = bokeh.plotting.figure(
+            width=600, height=300, title='', tools='pan,save',
+            x_range=(bins[binvar][0], bins[binvar][-1]+hshift),
+            y_range=(0.9,2.6),
+            y_axis_type='linear'
+        )
+
+        for ivar,avar in enumerate(avars):
+            bincenters = (bins[binvar][:-1]+bins[binvar][1:])/2
+            opt = dict(x=bincenters+wshifts[binvar][ivar],
+                       legend_label=dvar[avar][1],
+                       color=dvar[avar][2])
+
+            median = list(values[binvar][avar]['median'])
+            mean = list(values[binvar][avar]['mean'])
+            std = list(values[binvar][avar]['std'])
+            q1 = np.array(values[binvar][avar]['q1'])
+            q3 = np.array(values[binvar][avar]['q3'])
+            mopt = dict(y=mean)
+
+            # median
+            fcounts[binvar].square(size=8, **mopt, **opt)
+            fcounts[binvar].line(line_width=1, **mopt, **opt)
+            fcounts[binvar].line(x=[bincenters[0]-hshift, bincenters[-1]+hshift], y=[1.,1.],
+                              line_width=1, line_dash='dashed', color='gray')
+
+            # quantiles
+            source = bmd.ColumnDataSource(data=dict(base=bincenters + wshifts[binvar][ivar],
+                                                    errup=mean+std/(2*np.sqrt(len(std))),
+                                                    errdown=mean-std/(2*np.sqrt(len(std)))))
+            quant = bmd.Whisker(base='base', upper='errup', lower='errdown', source=source,
+                                level='annotation', line_width=2, line_color=dvar[avar][2])
+            quant.upper_head.size=10
+            quant.lower_head.size=10
+            quant.upper_head.line_color = dvar[avar][2]
+            quant.lower_head.line_color = dvar[avar][2]
+            fcounts[binvar].add_layout(quant)
+
+            fcounts[binvar].xaxis.axis_label = labels[binvar]
+            fcounts[binvar].yaxis.axis_label = 'Average'
+            common_props(fcounts[binvar])
+
+
+    # plot seeding efficiency
+    for vvv in ('has_seeds', 'less_seeds'):
+        for binvar in bins.keys():
+            figname = binvar + '_' + vvv
+            hshift = (bins[binvar][1]-bins[binvar][0])/2
+            feff[figname] = bokeh.plotting.figure(
+                width=600, height=300, title='', tools='save',
+                x_range=(bins[binvar][0], bins[binvar][-1]+hshift),
+                y_range=(0.6,1.4) if vvv=='has_seeds' else (-0.1,1.1),
+                y_axis_type='linear'
+            )
+     
+            bincenters = (bins[binvar][:-1]+bins[binvar][1:])/2
+            opt = dict(x=bincenters+wshifts[binvar][ivar], color=dvar[avar][2])
+     
+            k = np.array(values[binvar][vvv]['sum'])
+            n = np.array(values[binvar][vvv]['size'])
+            eff = k / n
+            feff[figname].square(y=eff, size=8, **opt)
+            feff[figname].line(line_width=1, **opt)
+            feff[figname].line(x=[bincenters[0]-hshift, bincenters[-1]+4*hshift], y=[1.,1.],
+                                    line_width=1, line_dash='dashed', color='gray')
+     
+            # errors
+            source = bmd.ColumnDataSource(data=dict(base=bincenters + wshifts[binvar][ivar],
+                                                    errup=eff+eff*np.sqrt(1/k+1/n)/2,
+                                                    errdown=eff-eff*np.sqrt(1/k+1/n)/2))
+            quant = bmd.Whisker(base='base', upper='errup', lower='errdown', source=source,
+                                level='annotation', line_width=2, line_color=dvar[avar][2])
+            quant.upper_head.size=10
+            quant.lower_head.size=10
+            quant.upper_head.line_color = dvar[avar][2]
+            quant.lower_head.line_color = dvar[avar][2]
+            feff[figname].add_layout(quant)
+
+            feff[figname].xaxis.axis_label = labels[binvar]
+            feff[figname].yaxis.axis_label = ('Seeding Efficiency' if vvv=='has_seeds'
+                                              else 'Fraction of events w/ #Seeds < #ROIs')
+            common_props(feff[figname], legend=False)
+            
+    if pars.sel.startswith('above_eta_'):
+        title_suf = ' (eta > ' + pars.selection.split('above_eta_')[1] + ')'
+    elif pars.sel == 'splits_only':
+        title_suf = '(split clusters only)'
+    elif pars.sel == 'no_splits':
+        title_suf = '(no split clusters)'
+
+    ncols = 4
+    sep = " <b>|</b> "
+    text = sep.join(('<b>Selection: </b>{} ({} events)'.format(pars.sel, df.shape[0]),
+                     '<b>Region: </b>{}'.format(pars.reg),
+                     '<b>Seed window: </b>{}'.format(pars.seed_window)))
+    div = bokeh.models.Div(width=1000, height=20, text=text)
+    lay_list = [[div],
+                [fcounts['en'], feff['en_has_seeds'], feff['en_less_seeds']],
+                [fcounts['eta'], feff['eta_has_seeds'], feff['eta_less_seeds']],
+                [fcounts['phi'], feff['phi_has_seeds'], feff['phi_less_seeds']]]
+    bokeh.io.save(bokeh.layouts.layout(lay_list))
+
+    return None
+
+def distribution_plotter(df, pars, user):
+    folder = get_folder_plots()
+    folder = os.path.join('/eos/user', user[0], user, 'www/L1/', folder)
+    common.create_dir(folder)
+    out = common.fill_path(os.path.join(folder, 'dist'), ext='html', **pars)
     bokeh.io.output_file(out)
 
     allfigs = []
     varpairs = (('roi', 'cl'),  ('resroi', 'rescl'))
 
-    nbeta, nbphi, nben = (25 for _ in range(3))
+    nbeta, nbphi, nben = 200, 200, 30
     bins = {'eta': {'def': np.linspace(df.geneta.min(), df.geneta.max(), nbeta+1),
                     'res': np.linspace(-0.6, 0, nbeta+1)},
             'phi': {'def': np.linspace(df.genphi.min(), df.genphi.max(), nbphi+1),
@@ -137,31 +299,33 @@ def distribution_plotter(df, pars, user):
             }
     labels = {'eta': {'def': '\u03B7', 'res': '\u03B7 resolution'},
               'phi': {'def': '\u03C6', 'res': '\u03C6 resolution'},
-              'en':  {'def': 'Energy [GeV]', 'res': 'Energy resolution'}}
+              'en':  {'def': 'Energy [GeV]', 'res': r'$$E/E_{Gen}-1$$'}}
+    wshifts = {'eta': {'roi': -0.01, 'cl': 0.01, 'resroi': -0.002, 'rescl': 0.002},
+               'phi': {'roi': -0.1, 'cl': 0.01, 'resroi': -0.002, 'rescl': 0.002},
+               'en':  {'roi': -10, 'cl': 10, 'resroi': -0.002, 'rescl': 0.002}}
     dvar = {'eta': ('Eta distribution',),
             'phi': ('Phi distribution',),
             'en': ('Energy distribution',)}
-    ranges = {'eta': {'def': (-2, 40), 'res': (-2, 100)},
-              'phi': {'def': (-2, 35), 'res': (-2, 100)},
-              'en':  {'def': (-2, 75), 'res': (-2, 100)}}
+    ranges = {'eta': {'def': (-2, 40), 'res': (-2, 170)},
+              'phi': {'def': (-2, 135), 'res': (-2, 120)},
+              'en':  {'def': (-2, 175), 'res': (-2, 120)}}
     
     for avars in varpairs:
         vstr = 'def' if avars==('roi', 'cl') else 'res'
-        values = {x: {avars[0]: np.array(df.groupby(pd.cut(df[avars[0]+x], bins[x][vstr])).size()),
-                      avars[1]: np.array(df.groupby(pd.cut(df[avars[1]+x], bins[x][vstr])).size())}
+        values = {x: {avars[0]: df.groupby(pd.cut(df[avars[0]+x], bins[x][vstr])).agg(['mean', 'std', 'size']),
+                      avars[1]: df.groupby(pd.cut(df[avars[1]+x], bins[x][vstr])).agg(['mean', 'std', 'size'])}
                   for x in bins.keys()}
-        
+
         figs = {x:None for x in labels.keys()}
-        values_d = {avars[0]: ('ROI', 'blue'),
+        values_d = {avars[0]: ('TCs', 'blue'),
                     avars[1]: ('Clusters', 'red')}
-     
+
         for il in labels.keys():
             hshift = (bins[il][vstr][1]-bins[il][vstr][0])/2
             figs[il] = bokeh.plotting.figure(
-                width=600, height=300, title='', tools='save',
+                width=600, height=300, title='', tools='pan,box_zoom,reset,save',
                 x_range=(bins[il][vstr][0], bins[il][vstr][-1]+4*hshift),
-                #y_range=(ymin-vshift, ymax+vshift),
-                y_range=ranges[il][vstr],
+                # y_range=ranges[il][vstr],
                 y_axis_type='linear'
             )
             figs[il].xaxis.axis_label = labels[il][vstr]
@@ -169,11 +333,29 @@ def distribution_plotter(df, pars, user):
             
             bincenters = (bins[il][vstr][:-1]+bins[il][vstr][1:])/2
             for avar in avars:
-                opt = dict(x=bincenters, y=values[il][avar],
+                size = list(values[il][avar][avar+il]['size'])
+                mean = list(values[il][avar][avar+il]['mean'])
+                std = list(values[il][avar][avar+il]['std'])
+                opt = dict(x=bincenters + wshifts[il][avar],
+                           y=size,
                            legend_label=values_d[avar][0],
                            color=values_d[avar][1])
+
+                # errors
+                source = bmd.ColumnDataSource(data=dict(base=bincenters + wshifts[il][avar],
+                                                        errup=size+np.sqrt(size),
+                                                        errdown=size-np.sqrt(size)))
+                quant = bmd.Whisker(base='base', upper='errup', lower='errdown', source=source,
+                                    level='annotation', line_width=2, line_color=values_d[avar][1])
+                quant.upper_head.size=10
+                quant.lower_head.size=10
+                quant.upper_head.line_color = values_d[avar][1]
+                quant.lower_head.line_color = values_d[avar][1]
+                figs[il].add_layout(quant)
+
                 figs[il].square(size=6, **opt)
                 figs[il].line(line_width=1, **opt)
+                
             common_props(figs[il])
 
         allfigs.append(figs)
@@ -194,7 +376,8 @@ def distribution_plotter(df, pars, user):
     div = bokeh.models.Div(width=1000, height=20, text=text)
     lay_list = [[div],
                 [allfigs[0]['en'],allfigs[1]['en']],
-                allfigs[0]['phi'], allfigs[0]['eta']]
+                [allfigs[0]['phi'],allfigs[1]['phi']],
+                [allfigs[0]['eta'],allfigs[1]['eta']]]
     bokeh.io.save(bokeh.layouts.layout(lay_list))
 
     return None

--- a/bye_splits/plot/roi_chain_plotter.py
+++ b/bye_splits/plot/roi_chain_plotter.py
@@ -236,6 +236,8 @@ def seed_plotter(df, pars, user):
             k = np.array(values[binvar][vvv]['sum'])
             n = np.array(values[binvar][vvv]['size'])
             eff = k / n
+            errup = [ee+ee*np.sqrt(1/kk+1/nn)/2  if kk!=0. else 0. for ee,kk,nn in zip(eff,k,n)]
+            errlo = [ee-ee*np.sqrt(1/kk+1/nn)/2  if kk!=0. else 0. for ee,kk,nn in zip(eff,k,n)]
             feff[figname].square(y=eff, size=8, **opt)
             feff[figname].line(line_width=1, **opt)
             feff[figname].line(x=[bincenters[0]-hshift, bincenters[-1]+4*hshift], y=[1.,1.],
@@ -243,8 +245,7 @@ def seed_plotter(df, pars, user):
      
             # errors
             source = bmd.ColumnDataSource(data=dict(base=bincenters + wshifts[binvar][ivar],
-                                                    errup=eff+eff*np.sqrt(1/k+1/n)/2,
-                                                    errdown=eff-eff*np.sqrt(1/k+1/n)/2))
+                                                    errup=errup, errdown=errlo))
             quant = bmd.Whisker(base='base', upper='errup', lower='errdown', source=source,
                                 level='annotation', line_width=2, line_color=dvar[avar][2])
             quant.upper_head.size=10

--- a/bye_splits/plot/roi_uv_space.py
+++ b/bye_splits/plot/roi_uv_space.py
@@ -20,10 +20,34 @@ from bokeh.util.hex import axial_to_cartesian
 import utils
 from utils import params, common, parsing
 
+import tasks
+from tasks.seed_roi import dist
+
+def add_centrals_info(roi_ev, centr):
+    """
+    A negative number indicates a wafer that is not the cente rof any ROI in the event.
+    A positive number indicates a wafer that is the center of a ROI in the event.
+    Zero is not assigned.
+    """
+    roi_ev['central_roi'] = 0
+    for ic,c in enumerate(centr):
+        iscentral = (roi_ev.tc_wu==c[0]) & (roi_ev.tc_wv==c[1])
+        roi_ev.loc[iscentral, 'central_roi'] = ic+1
+        
+    non_centrals = roi_ev[roi_ev.central_roi == 0]
+    non_centrals = non_centrals[['tc_wu', 'tc_wv']].drop_duplicates().to_numpy()
+    for ip,pair in enumerate(non_centrals):
+        sel = (roi_ev.tc_wu==pair[0]) & (roi_ev.tc_wv==pair[1])
+        roi_ev.loc[sel, 'central_roi'] = -ip-1
+    return roi_ev
+
+def coord_transf(cu, wu, cv, wv):
+    nside = 4
+    return cu - nside*wu + 2*nside*wv, cv - 2*nside*wu + nside*wv
+    
 def calc_universal_coordinates(df, varu='univ_u', varv='univ_v'):
     nside = 4
-    df[varu] = df.tc_cu - nside*df.tc_wu + 2*nside*df.tc_wv
-    df[varv] = df.tc_cv - 2*nside*df.tc_wu + nside*df.tc_wv
+    df[varu], df[varv] = coord_transf(df.tc_cu, df.tc_wu, df.tc_cv, df.tc_wv)
     df[varu] = df[varu] - df[varu].min()
     df[varv] = df[varv] - df[varv].min()
     return df
@@ -41,7 +65,8 @@ def create_bokeh_datatable(src, width, height):
                  'tc_wv': 'Wafer V',
                  'tc_cu': 'Trigger Cell U',
                  'tc_cv': 'Trigger Cell V',
-                 'tc_mipPt': 'Energy [mipPt]'}
+                 'tc_mipPt': 'Energy [mipPt]',
+                 'tc_energy': 'Energy [GeV]'}
 
     template_ints="""<b><div><%= (value).toFixed(0) %></div></b>"""
     template_floats="""<b><div><%= (value).toFixed(3) %></div></b>"""
@@ -51,40 +76,72 @@ def create_bokeh_datatable(src, width, height):
             for x in ['tc_wu', 'tc_wv', 'tc_cu', 'tc_cv']]
     cols.extend([bmd.TableColumn(field='tc_mipPt', title=col_names['tc_mipPt'],
                                  formatter=ff)])
+    cols.extend([bmd.TableColumn(field='tc_energy', title=col_names['tc_energy'],
+                                 formatter=ff)])
     table_opt = dict(width=width, height=int(0.7*height), source=src)
     table = bmd.DataTable(columns=cols, **table_opt)
     return table
-            
-def roi_event_loop(pars, **kw):
-    in_tcs = common.fill_path(kw['SeedIn']+'_'+kw['FesAlgo'], **pars)
-    uv_vars = ['univ_u', 'univ_v', 'tc_cu', 'tc_cv', 'tc_wu', 'tc_wv']
-    tabs_one, tabs_many = ([] for _ in range(2))
+
+def dist(u1, v1, u2, v2):
+    """distance in an hexagonal grid"""
+    s1 = u1 - v1
+    s2 = u2 - v2
+    return (abs(u1-u2) + abs(v1-v2) + abs(s1-s2)) / 2
     
-    nn = 0
-    ntabs = 10
+def roi_event_loop(pars, **kw):
+    in_tcs = common.fill_path(kw['SeedIn'], **pars)
+    uv_vars = ['univ_u', 'univ_v', 'tc_cu', 'tc_cv', 'tc_wu', 'tc_wv']
+    tabs = []
+    
+    ntabs = 18
     if FLAGS.fullroi:
         # randomly center on wafer (3,5)
-        allowed = ('35', '36', '25' ,'24', '34', '45', '45', '46')
-        arrcv = np.array([0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,
-                          4,4,4,4,5,5,5,5,6,6,6,6,7,7,7,7,
-                          0,1,2,3,1,2,3,4,2,3,4,5,3,4,5,6])
+        center = '35'
+        allowed = (center, '36', '25' ,'24', '34', '45', '45', '46')
+
+        # cell indices of TCs in the wafer
         arrcu = np.array([1,2,3,4,2,3,4,5,3,4,5,6,4,5,6,7,
                           4,5,6,7,4,5,6,7,4,5,6,7,4,5,6,7,
                           0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3])
+        arrcv = np.array([0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,
+                          4,4,4,4,5,5,5,5,6,6,6,6,7,7,7,7,
+                          0,1,2,3,1,2,3,4,2,3,4,5,3,4,5,6])
+
+        # cell indices of TCs in the border of the wafer
+        uborder = np.array([1,2,3,4,5,6,7,7,7,7,7,6,5,4,3,2,1,0,0,0,0])
+        vborder = np.array([0,0,0,0,1,2,3,4,5,6,7,7,7,7,6,5,4,3,2,1,0])
+        # universal coordinates of TCs in the center wafer's border
+        uborder, vborder = coord_transf(uborder, int(center[0]), vborder, int(center[1]))
+
         assert arrcv.shape==arrcu.shape
 
         toy = pd.DataFrame()
         for wu in range(2,5):
             for wv in range(4,7):
-                if str(wu)+str(wv) in allowed:
-                    arrwu = np.repeat(wu,arrcu.shape[0])
-                    arrwv = np.repeat(wv,arrcv.shape[0])
-                    toytmp = pd.DataFrame({'tc_wu': arrwu,
-                                           'tc_wv': arrwv,
-                                           'tc_cu': arrcu,
-                                           'tc_cv': arrcv})
-                    toy = pd.concat((toy,toytmp), axis=0)
-                    
+                wafer = str(wu)+str(wv)
+                if wafer not in allowed:
+                    continue
+
+                if wafer == center:
+                    colors = np.full(arrcv.shape, 'saddlebrown')
+                else:
+                    colors = np.full(arrcv.shape, 'bisque')
+
+                    # universal coordinates of TCs in neighbouring wafer
+                    uneigh, vneigh = coord_transf(arrcu, wu, arrcv, wv)
+
+                    # change neighbours' color
+                    for ub, vb in zip(uborder, vborder):
+                        dists = dist(uneigh, vneigh, ub, vb)
+                        colors[dists <= 1] = 'cyan'
+
+                toytmp = pd.DataFrame({'tc_wu': np.repeat(wu,arrcu.shape[0]),
+                                       'tc_wv': np.repeat(wv,arrcv.shape[0]),
+                                       'tc_cu': arrcu,
+                                       'tc_cv': arrcv,
+                                       'colors': colors,
+                                       })
+                toy = pd.concat((toy,toytmp), axis=0)
 
         toy = toy.reset_index()[toy.columns]
         toy = calc_universal_coordinates(toy, varu=uv_vars[0], varv=uv_vars[1])
@@ -94,36 +151,31 @@ def roi_event_loop(pars, **kw):
         
     else:
         store_roi = pd.HDFStore(in_tcs, mode='r')
-        unev = store_roi.keys()
+        unev = [x for x in store_roi.keys() if 'central' not in x]
+        inspect_events = ('165405',)
         for key in unev:
             roi_ev = store_roi[key]
+            roi_uvcentrals = store_roi[key + 'central'].to_numpy()
+            
             roi_ev = calc_universal_coordinates(roi_ev, varu=uv_vars[0], varv=uv_vars[1])
-     
-            if len(roi_ev['tc_wu'].unique())==1 and len(roi_ev['tc_wv'].unique())==1:
-                neighbours = False
-            else:
-                neighbours = True
-                nn += 1
-            roi_ev = roi_ev.groupby(by=uv_vars).sum()[['tc_mipPt']].reset_index()
-     
+            roi_ev = roi_ev.groupby(by=uv_vars).sum()[['tc_mipPt', 'tc_energy']].reset_index()
+            roi_ev = add_centrals_info(roi_ev, roi_uvcentrals)
+
             lay = create_roi_tab(roi_ev)
-            tab_title = re.findall('\d+', key)[0]
+            tab_title = re.findall('.*_([0-9]{1,7})_.*', key)[0]
             panel = bmd.TabPanel(child=lay, title=tab_title)
-            if neighbours==True:
-                if len(tabs_many) < ntabs:
-                    tabs_many.append(panel)
-            else:
-                if len(tabs_one) < ntabs:
-                    tabs_one.append(panel)
-     
-            if len(tabs_one) > ntabs and len(tabs_many) > ntabs:
+            if len(tabs) < ntabs or any([x in key for x in inspect_events]):
+                tabs.append(panel)
+
+            if '165405' in key:
+                inspected = True
+
+            if len(tabs) > ntabs and inspected:
                 break
             
         store_roi.close()
-        print('There are {}/{} ROIs with neighbours.'.format(nn,len(unev)))
         
-        plot_all_rois(tabs_one, 'uv_to_square_one.html')
-        plot_all_rois(tabs_many, 'uv_to_square_many.html')
+        plot_all_rois(tabs, 'uv_to_square.html')
 
 def source_maxmin(src, varu, varv):
     # find dataset minima and maxima
@@ -162,6 +214,14 @@ def create_roi_tab(df):
     basic_tools = 'pan,save,reset,undo,box_select'
 
     df = add_bokeh_coord_convention(df, 'univ_u', 'univ_v')
+    if not FLAGS.fullroi:
+        mypalette = _palette(50)
+        mapper = bmd.LinearColorMapper(palette=mypalette,
+                                       low=df.tc_mipPt.min(), high=df.tc_mipPt.max())
+        cbar_opt = dict(ticker=bmd.BasicTicker(desired_num_ticks=int(len(mypalette)/4)),
+                        formatter=bmd.PrintfTickFormatter(format="%d"))
+        cbar = bmd.ColorBar(color_mapper=mapper, title='TC energy [mipPt]', **cbar_opt)
+
     source = bmd.ColumnDataSource(df)
     hexq = source.data['q_bokeh']
     hexr = source.data['r_bokeh']
@@ -183,9 +243,18 @@ def create_roi_tab(df):
 
     uv_r = p_uv.hex_tile(q='q_bokeh', r='r_bokeh', orientation='flattop',
                          source=source,
-                         size=hexsize, fill_color='green', line_color='black',
+                         size=hexsize,
+                         fill_color=('colors' if FLAGS.fullroi
+                                     else {'field': 'tc_mipPt', 'transform': mapper}),
+                         line_color='black',
                          line_width=3, alpha=1., **hover_opt)
-    hvr_tt = [('cu,cv/wu,wv', '@tc_cu,@tc_cv/@tc_wu,@tc_wv')]
+    if not FLAGS.fullroi:
+        p_uv.add_layout(cbar, 'right')
+
+    if FLAGS.fullroi:
+        hvr_tt = [('cu,cv/wu,wv', '@tc_cu,@tc_cv/@tc_wu,@tc_wv')]
+    else:
+        hvr_tt = [('mipPt [mipPt] / energy [GeV] / ROI id', '@tc_mipPt / @tc_energy / @central_roi')]
     p_uv.add_tools(bmd.WheelZoomTool(),
                    bmd.HoverTool(tooltips=hvr_tt, renderers=[uv_r]))
 
@@ -206,8 +275,12 @@ def create_roi_tab(df):
     xy_r = p_xy.rect(x='univ_u', y='univ_v', source=source,
                      width=1., height=1.,
                      width_units='data', height_units='data',
-                     fill_color='red', line_color='black', line_width=3,
+                     fill_color=('colors' if FLAGS.fullroi
+                                 else {'field': 'tc_mipPt', 'transform': mapper}),
+                     line_color='black', line_width=3,
                      **hover_opt)
+    if not FLAGS.fullroi:
+        p_xy.add_layout(cbar, 'right')
     p_xy.text(hexcu, hexcv,
               text=['{},{}'.format(q,r) for (q, r) in zip(hexcu, hexcv)],
               text_baseline='middle', text_align='center',

--- a/bye_splits/scripts/run_default_chain.py
+++ b/bye_splits/scripts/run_default_chain.py
@@ -26,7 +26,7 @@ def run_chain(pars):
     """Run the backend stage 2 reconstruction chain for a single event."""
     df_out = None
 
-    df_gen, df_cl, df_tc = get_data_reco_chain_start(nevents=100, reprocess=True)
+    df_gen, df_cl, df_tc = get_data_reco_chain_start(nevents=1000, reprocess=True)
 
     print("There are {} events in the input.".format(df_gen.shape[0]))
 

--- a/bye_splits/scripts/run_roi_chain.py
+++ b/bye_splits/scripts/run_roi_chain.py
@@ -33,31 +33,43 @@ def run_roi_chain(pars):
         seed_d = params.read_task_params('seed_roi')
         tasks.seed_roi.seed_roi(pars, **seed_d)
 
+    if not pars.no_valid_seed:
+        valid_d = params.read_task_params('valid_seed')
+        stats_out_seed = tasks.validation_roi.stats_collector_seed(pars, **valid_d)
+        roi_chain_plotter.seed_plotter(stats_out_seed, pars, user='bfontana')
+
     if not pars.no_cluster:
         cluster_d = params.read_task_params('cluster')
         nevents_end = tasks.cluster.cluster_roi(pars, **cluster_d)
         print('There are {} events in the output.'.format(nevents_end))
 
-    if not pars.no_validation:
+    if not pars.no_valid_cluster:
         # compare CMSSW with local reconstruction
-        valid_d = params.read_task_params('valid_roi')
-        # tasks.validation.validation(pars, **valid_d)
-        
-        stats_out = tasks.validation_roi.stats_collector_roi(pars, mode='resolution', **valid_d)
-        #roi_chain_plotter.resolution_plotter(stats_out, pars, user='bfontana')
-        roi_chain_plotter.distribution_plotter(stats_out, pars, user='bfontana')
+        valid_d = params.read_task_params('valid_cluster')
+
+        # validate the clustering
+        stats_out_cluster = tasks.validation_roi.stats_collector_roi(pars, mode='resolution', **valid_d)
+        roi_chain_plotter.resolution_plotter(stats_out_cluster, pars, user='bfontana')
+        roi_chain_plotter.distribution_plotter(stats_out_cluster, pars, user='bfontana')
 
     return None
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Full reconstruction chain.')
-    parser.add_argument('--no_roi', action='store_true')
-    parser.add_argument('--no_seed', action='store_true')
-    parser.add_argument('--no_cluster', action='store_true')
-    parser.add_argument('--no_validation', action='store_true')
+    parser = argparse.ArgumentParser(description='Full reconstruction chain.',
+                                     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--no_roi',           action='store_true', help='do not run the roi finder step')
+    parser.add_argument('--no_seed',          action='store_true', help='do not run the seeding step')
+    parser.add_argument('--no_cluster',       action='store_true', help='do not run the clustering step')
+    parser.add_argument('--no_valid',         action='store_true', help='do not run any validation')
+    parser.add_argument('--no_valid_seed',    action='store_true', help='do not run ROI seed validation')
+    parser.add_argument('--no_valid_cluster', action='store_true', help='do not run ROI cluster validation')
     parsing.add_parameters(parser)
     FLAGS = parser.parse_args()
+    if FLAGS.no_valid:
+        FLAGS.no_valid_seed = True
+        FLAGS.no_valid_cluster = True
+        
     assert (FLAGS.sel in ('splits_only', 'no_splits', 'all') or
             FLAGS.sel.startswith('above_eta_'))
 

--- a/bye_splits/scripts/run_roi_chain.py
+++ b/bye_splits/scripts/run_roi_chain.py
@@ -21,7 +21,7 @@ import argparse
 
 def run_roi_chain(pars):
     '''Run the backend stage 2 reconstruction chain for a single event.'''
-    df_gen, df_cl, df_tc = get_data_reco_chain_start(nevents=1000, reprocess=False, tag='roi_chain')
+    df_gen, df_cl, df_tc = get_data_reco_chain_start(nevents=100, reprocess=False, tag='roi_chain')
 
     print('There are {} events in the input.'.format(df_gen.shape[0]))
 

--- a/bye_splits/tasks/cluster.py
+++ b/bye_splits/tasks/cluster.py
@@ -24,7 +24,7 @@ def cluster(pars, in_seeds, in_tc, out_valid, out_plot, **kw):
     sout = pd.HDFStore(out_valid, mode='w')
     stc = h5py.File(in_tc, mode='r')
         
-    seed_keys = [x for x in sseeds.keys() if '_tc' in x and 'central' not in x]
+    seed_keys = [x for x in sseeds.keys() if '_group' in x and 'central' not in x]
     tc_keys = [x for x in stc.keys() if '_tc' in x and 'central' not in x]
     assert len(seed_keys) == len(tc_keys)
 

--- a/bye_splits/tasks/cluster.py
+++ b/bye_splits/tasks/cluster.py
@@ -10,136 +10,148 @@ sys.path.insert(0, parent_dir)
 
 import bye_splits
 from bye_splits import utils
-from bye_splits.utils import common
+from bye_splits.utils import common, params
 
 import re
+import yaml
 import numpy as np
 import pandas as pd
 import h5py
 
 def cluster(pars, in_seeds, in_tc, out_valid, out_plot, **kw):
     dfout = None
-    with h5py.File(in_seeds, mode="r") as sin_seeds, h5py.File(in_tc, mode="r") as sin_tc, pd.HDFStore(out_valid, mode="w") as sout:
-        seed_keys = [x for x in sin_seeds.keys() if "_group" in x]
-        tc_keys = [x for x in sin_tc.keys() if "_tc" in x]
-        assert len(seed_keys) == len(tc_keys)
+    sseeds = h5py.File(in_seeds, mode='r')
+    sout = pd.HDFStore(out_valid, mode='w')
+    stc = h5py.File(in_tc, mode='r')
+        
+    seed_keys = [x for x in sseeds.keys() if '_tc' in x and 'central' not in x]
+    tc_keys = [x for x in stc.keys() if '_tc' in x and 'central' not in x]
+    assert len(seed_keys) == len(tc_keys)
 
-        radiusCoeffB = kw["CoeffB"]
-        empty_seeds = 0
+    radiusCoeffB = kw["CoeffB"]
+    empty_seeds = 0
 
-        for tck, seedk in zip(tc_keys, seed_keys):
-            tc = sin_tc[tck]
-            tc_cols = list(tc.attrs["columns"])
+    for tck, seedk in zip(tc_keys, seed_keys):
+        tc = stc[tck]
+        tc_cols = list(tc.attrs["columns"])
 
-            radiusCoeffA = np.array([kw["CoeffA"][int(xi) - 1]
-                                     for xi in tc[:, tc_cols.index("tc_layer")]])
-            minDist = radiusCoeffA + radiusCoeffB * (
-                kw["MidRadius"] - np.abs(tc[:, tc_cols.index("tc_eta")])
-            )
+        radiusCoeffA = np.array([kw["CoeffA"][int(xi) - 1]
+                                 for xi in tc[:, tc_cols.index("tc_layer")]])
+        minDist = radiusCoeffA + radiusCoeffB * (
+            kw["MidRadius"] - np.abs(tc[:, tc_cols.index("tc_eta")])
+        )
+        seedEn, seedXdivZ, seedYdivZ = sseeds[seedk]
 
-            seedEn, seedXdivZ, seedYdivZ = sin_seeds[seedk]
+        dRs = np.array([])
+        z_tmp = tc[:, tc_cols.index("tc_z")]
+        projx = tc[:, tc_cols.index("tc_x")] / z_tmp
+        projy = tc[:, tc_cols.index("tc_y")] / z_tmp
 
-            dRs = np.array([])
-            z_tmp = tc[:, tc_cols.index("tc_z")]
-            projx = tc[:, tc_cols.index("tc_x")] / z_tmp
-            projy = tc[:, tc_cols.index("tc_y")] / z_tmp
+        for _, (en, sx, sy) in enumerate(zip(seedEn, seedXdivZ, seedYdivZ)):
+            dR = np.sqrt((projx - sx) * (projx - sx) + (projy - sy) * (projy - sy))
+            if dRs.shape == (0,):
+                dRs = np.expand_dims(dR, axis=-1)
+            else:
+                dRs = np.concatenate((dRs, np.expand_dims(dR, axis=-1)), axis=1)
 
-            for _, (en, sx, sy) in enumerate(zip(seedEn, seedXdivZ, seedYdivZ)):
-                dR = np.sqrt((projx - sx) * (projx - sx) + (projy - sy) * (projy - sy))
-                if dRs.shape == (0,):
-                    dRs = np.expand_dims(dR, axis=-1)
-                else:
-                    dRs = np.concatenate((dRs, np.expand_dims(dR, axis=-1)), axis=1)
+        # checks if each event has at least one seed laying below the threshold
+        thresh = dRs < np.expand_dims(minDist, axis=-1)
 
-            # checks if each event has at least one seed laying below the threshold
-            thresh = dRs < np.expand_dims(minDist, axis=-1)
-            thresh = np.logical_or.reduce(thresh, axis=1)
+        try:
+            # assign TCs to the closest seed (within a maximum distance)
+            if pars["cluster_algo"] == "min_distance":
+                thresh = np.logical_or.reduce(thresh, axis=1)
+                seeds_indexes = np.argmin(dRs, axis=1)
 
-            try:
-                # assign TCs to the closest seed
-                if pars["cluster_algo"] == "min_distance":
-                    seeds_indexes = np.argmin(dRs, axis=1)
-
-                # most energetic seed takes all
-                elif pars["cluster_algo"] == "max_energy":
-                    seed_max = np.argmax(seedEn)
-                    seeds_indexes = np.full((tc.shape[0],), seed_max)
-
-            except np.AxisError:
+            # energy prioritization (within a maximum distance)
+            elif pars["cluster_algo"] == "max_energy":
+                filter_en = seedEn * thresh
+                thresh = np.max(filter_en, axis=1) > 0
+                seeds_indexes = np.argmax(filter_en, axis=1)
+                
+        except np.AxisError:
+            empty_seeds += 1
+            continue
+        except ValueError:
+            if len(seedEn)==0:
                 empty_seeds += 1
                 continue
-
-            seeds_energies = np.array([seedEn[xi] for xi in seeds_indexes])
-            # axis 0 stands for trigger cells
-            assert tc[:].shape[0] == seeds_energies.shape[0]
-
-            seeds_indexes = np.expand_dims(seeds_indexes[thresh], axis=-1)
-            seeds_energies = np.expand_dims(seeds_energies[thresh], axis=-1)
-
-            tc = tc[:][thresh]
-
-            res = np.concatenate((tc, seeds_indexes, seeds_energies), axis=1)
-
-            key = tck.replace("_tc", "_cl")
-            cols = tc_cols + ["seed_idx", "seed_energy"]
-            assert len(cols) == res.shape[1]
-
-            df = pd.DataFrame(res, columns=cols)
-            df["cl3d_pos_x"] = df.tc_x * df.tc_mipPt
-            df["cl3d_pos_y"] = df.tc_y * df.tc_mipPt
-            df["cl3d_pos_z"] = df.tc_z * df.tc_mipPt
-
-            cl3d_cols = ["cl3d_pos_x", "cl3d_pos_y", "cl3d_pos_z", "tc_mipPt", "tc_pt"]
-            cl3d = df.groupby(["seed_idx"]).sum()[cl3d_cols]
-            cl3d = cl3d.rename(
-                columns={
-                    "cl3d_pos_x": "x",
-                    "cl3d_pos_y": "y",
-                    "cl3d_pos_z": "z",
-                    "tc_mipPt": "mipPt",
-                    "tc_pt": "pt",
-                }
-            )
-
-            cl3d = cl3d[cl3d.pt > kw["PtC3dThreshold"]]
-            cl3d.loc[:, ["x", "y", "z"]] = cl3d.loc[:, ["x", "y", "z"]].div(
-                cl3d.mipPt, axis=0
-            )
-
-            cl3d_dist = np.sqrt(cl3d.x**2 + cl3d.y**2)
-            cl3d["phi"] = np.arctan2(cl3d.y, cl3d.x)
-            cl3d["eta"] = np.arcsinh(cl3d.z / cl3d_dist)
-            cl3d["Rz"] = common.calcRzFromEta(cl3d.eta)
-            cl3d["en"] = cl3d.pt * np.cosh(cl3d.eta)
-
-            search_str = "{}_([0-9]{{1,7}})_tc".format(kw["FesAlgo"])
-            event_number = re.search(search_str, tck)
-            if not event_number:
-                m = "The event number was not extracted!"
-                raise ValueError(m)
-
-            cl3d["event"] = event_number.group(1)
-            cl3d_cols = ["en", "x", "y", "z", "Rz", "eta", "phi"]
-            sout[key] = cl3d[cl3d_cols]
-            if tck == tc_keys[0] and seedk == seed_keys[0]:
-                dfout = cl3d[cl3d_cols + ["event"]]
             else:
-                dfout = pd.concat((dfout, cl3d[cl3d_cols + ["event"]]), axis=0)
+                raise
 
-        print(
-            "[clustering step] There were {} events without seeds.".format(empty_seeds)
+        seeds_energies = np.array([seedEn[xi] for xi in seeds_indexes])
+        # axis 0 stands for trigger cells
+        assert tc[:].shape[0] == seeds_energies.shape[0]
+
+        seeds_indexes = np.expand_dims(seeds_indexes[thresh], axis=-1)
+        seeds_energies = np.expand_dims(seeds_energies[thresh], axis=-1)
+        tc = tc[:][thresh]
+
+        res = np.concatenate((tc, seeds_indexes, seeds_energies), axis=1)
+
+        key = tck.replace("_tc", "_cl")
+        cols = tc_cols + ["seed_idx", "seed_energy"]
+        assert len(cols) == res.shape[1]
+
+        df = pd.DataFrame(res, columns=cols)
+        assert not df.empty
+
+        df["cl3d_pos_x"] = df.tc_x * df.tc_mipPt
+        df["cl3d_pos_y"] = df.tc_y * df.tc_mipPt
+        df["cl3d_pos_z"] = df.tc_z * df.tc_mipPt
+
+        cl3d_cols = ["cl3d_pos_x", "cl3d_pos_y", "cl3d_pos_z", "tc_mipPt", "tc_pt"]
+        cl3d = df.groupby(["seed_idx"]).sum()[cl3d_cols]
+        cl3d = cl3d.rename(
+            columns={
+                "cl3d_pos_x": "x",
+                "cl3d_pos_y": "y",
+                "cl3d_pos_z": "z",
+                "tc_mipPt": "mipPt",
+                "tc_pt": "pt",
+            }
         )
 
-    if dfout is not None:
-        with pd.HDFStore(out_plot, mode="w") as sout:
-            dfout.event = dfout.event.astype(int)
-            sout["data"] = dfout
-        nevents = dfout.event.unique().shape[0]
+        cl3d = cl3d[cl3d.pt > kw["PtC3dThreshold"]]
+        cl3d.loc[:, ["x", "y", "z"]] = cl3d.loc[:, ["x", "y", "z"]].div(
+            cl3d.mipPt, axis=0
+        )
 
+        cl3d_dist = np.sqrt(cl3d.x**2 + cl3d.y**2)
+        cl3d["phi"] = np.arctan2(cl3d.y, cl3d.x)
+        cl3d["eta"] = np.arcsinh(cl3d.z / cl3d_dist)
+        cl3d["Rz"] = common.calcRzFromEta(cl3d.eta)
+        cl3d["en"] = cl3d.pt * np.cosh(cl3d.eta)
+
+        search_str = "{}_([0-9]{{1,7}})_tc".format(kw["FesAlgo"])
+        event_number = re.search(search_str, tck)
+        if not event_number:
+            m = "The event number was not extracted!"
+            raise ValueError(m)
+
+        cl3d["event"] = event_number.group(1)
+        cl3d_cols = ["en", "x", "y", "z", "Rz", "eta", "phi"]
+        sout[key] = cl3d[cl3d_cols]
+        if tck == tc_keys[0] and seedk == seed_keys[0]:
+            dfout = cl3d[cl3d_cols + ["event"]]
+        else:
+            dfout = pd.concat((dfout, cl3d[cl3d_cols + ["event"]]), axis=0)
+
+    print("[clustering step] There were {} events without seeds.".format(empty_seeds))
+
+    splot = pd.HDFStore(out_plot, mode='w')
+    if dfout is not None:
+        dfout.event = dfout.event.astype(int)
+        splot["data"] = dfout        
     else:
         mes = "No output in the cluster."
         raise RuntimeError(mes)
 
+    nevents = dfout.event.unique().shape[0]
+    sseeds.close()
+    sout.close()
+    stc.close()
+    splot.close()
     return nevents
 
 def cluster_default(pars, **kw):
@@ -150,10 +162,20 @@ def cluster_default(pars, **kw):
     return cluster(pars, in_seeds, in_tc, out_valid, out_plot, **kw)
     
 def cluster_roi(pars, **kw):
-    in_seeds  = common.fill_path(kw["ClusterInSeedsROI"], **pars)
-    in_tc     = common.fill_path(kw["ClusterInTCROI"], **pars)
-    out_valid = common.fill_path(kw["ClusterOutValidationROI"], **pars)
-    out_plot  = common.fill_path(kw["ClusterOutPlotROI"], **pars)
+    with open(params.CfgPath, 'r') as afile:
+        cfg = yaml.safe_load(afile)
+    extra_name = '_hexdist' if cfg['seed_roi']['hexDist'] else ''
+    
+    in_seeds  = common.fill_path(kw["ClusterInSeedsROI"] + extra_name, **pars)
+    if cfg['cluster']['ROICylinder']:
+        in_tc = common.fill_path(kw["ClusterInTCROICylinder"], **pars)
+        out_valid = common.fill_path(kw["ClusterOutValidationROI"] + '_cyl', **pars)
+        out_plot  = common.fill_path(kw["ClusterOutPlotROI"] + '_cyl', **pars)
+    else:
+        in_tc = common.fill_path(kw["ClusterInTCROI"], **pars)
+        out_valid = common.fill_path(kw["ClusterOutValidationROI"], **pars)
+        out_plot  = common.fill_path(kw["ClusterOutPlotROI"], **pars)
+
     return cluster(pars, in_seeds, in_tc, out_valid, out_plot, **kw)
 
 if __name__ == "__main__":

--- a/bye_splits/tasks/roi.py
+++ b/bye_splits/tasks/roi.py
@@ -36,7 +36,6 @@ def get_roi_cylinder(ev_tc, roi_tcs):
     return ev_tc[(ev_tc.tc_wu.isin(uniqueu)) & (ev_tc.tc_wv.isin(uniquev)) &
                  (ev_tc.tc_layer <= ncee)]
 
-    
 def roi(pars, df_gen, df_cl, df_tc, **kw):
     """Waiting for ROI future algorithms..."""
     pass
@@ -52,21 +51,21 @@ def roi_dummy_calculator(tcs, k=4, threshold=20, nearby=True):
 
     mask = (tcs.tc_layer>=initial_layer) & (tcs.tc_layer<(availLayers[availLayers.index(initial_layer)+k]))
     input_df = tcs[mask]
-        
+    roi_df = pd.DataFrame()
+    
     module_sums = create_module_sums(input_df)
     module_ROI = list(module_sums[module_sums.values >= threshold].index)
-
     if nearby:
-        selected_modules = []
-        for module in module_ROI:
-            nearby_modules = [(module[0]+i, module[1]+j) for i in [-1, 0, 1] for j in [-1, 0, 1] if i*j >= 0]
-            skim = (module_sums.index.isin(nearby_modules)) & (module_sums.values > 0.3 * module_sums[module]) & (module_sums.values > 10)
-            skim_nearby_module = list(module_sums[skim].index)
-            selected_modules.extend(skim_nearby_module)
-        module_ROI = selected_modules
-    
-    roi_df = input_df[input_df.set_index(['tc_wu','tc_wv']).index.isin(module_ROI)]
-    return roi_df
+        for im, module in enumerate(module_ROI):
+            nearby_modules = [(module[0]+s, module[1]-r)
+                              for s in [-1,0,1] for r in [-1,0,1] for q in [-1,0,1]
+                              if s + r + q == 0]
+            tc_roi = input_df[input_df.set_index(['tc_wu','tc_wv']).index.isin(nearby_modules)]
+            with common.SupressSettingWithCopyWarning():
+                tc_roi['roi_id'] = im
+            roi_df = pd.concat((roi_df, tc_roi), axis=0)                
+
+    return roi_df, pd.DataFrame(module_ROI)
 
 def roi_calculator():
     pass
@@ -84,6 +83,7 @@ def roi(pars, df_gen, df_cl, df_tc, **kw):
 
     out_cl = common.fill_path(kw['ROIclOut'], **pars)
     out_tc = common.fill_path(kw['ROItcOut'], **pars)
+    out_tc2 = common.fill_path(kw['ROItcOut2'], **pars)
     out_cylinder = common.fill_path(kw['ROIcylinderOut'], **pars)
     with pd.HDFStore(out_cl, mode='w') as store_cl:
         store_cl['df'] = df_cl
@@ -91,6 +91,7 @@ def roi(pars, df_gen, df_cl, df_tc, **kw):
     ## Event-by-event processing
     store_tc = pd.HDFStore(out_tc, mode='w')
     store_cylinder = h5py.File(out_cylinder, mode='w')
+    store_all = h5py.File(out_tc2, mode='w') #duplication of information in non-pandas format
     unev = df_tc['event'].unique().astype('int')
     for ev in unev:
         ev_tc = df_tc[df_tc.event == ev]
@@ -98,12 +99,12 @@ def roi(pars, df_gen, df_cl, df_tc, **kw):
         if ev_tc.empty:
             continue
 
-        roi_tcs = roi_dummy_calculator(ev_tc) # roi_calculator()
+        roi_tcs, uvcentral = roi_dummy_calculator(ev_tc) # roi_calculator()
         if roi_tcs.empty:
             continue
 
         roi_keep = ['tc_wu', 'tc_wv', 'tc_cu', 'tc_cv', 'tc_x', 'tc_y', 'tc_z',
-                    'tc_layer', 'tc_mipPt', 'tc_pt']
+                    'tc_layer', 'tc_mipPt', 'tc_pt', 'tc_energy', 'roi_id']
         roi_tcs = roi_tcs.filter(items=roi_keep)
 
         divz = lambda pos: ev_tc.tc_mipPt*pos/np.abs(ev_tc.tc_z)
@@ -111,9 +112,11 @@ def roi(pars, df_gen, df_cl, df_tc, **kw):
         roi_tcs['wght_y'] = divz(ev_tc.tc_y)
 
         keybase = kw['FesAlgo'] + '_' + str(ev) + '_'
-        keytc = keybase + 'group'
+        keytc = keybase + 'tc'
         store_tc[keytc] = roi_tcs
         store_tc[keytc].attrs['columns'] = roi_keep
+        store_tc[keytc + 'central'] = uvcentral
+        store_tc[keytc + 'central'].attrs['columns'] = ['central_u', 'central_v']
         
         keycyl = keybase + 'tc'
         cylinder_tcs = get_roi_cylinder(ev_tc, roi_tcs)
@@ -123,9 +126,14 @@ def roi(pars, df_gen, df_cl, df_tc, **kw):
         store_cylinder[keycyl] = cylinder_tcs.to_numpy()
         store_cylinder[keycyl].attrs['columns'] = cyl_keep
 
-    nout = len(store_tc.keys())
+        all_tcs = ev_tc.filter(items=cyl_keep)
+        store_all[keycyl] = all_tcs.to_numpy()
+        store_all[keycyl].attrs['columns'] = cyl_keep
+
+    nout = int(len(store_tc.keys())/2)
     store_tc.close()
     store_cylinder.close()
+    store_all.close()
 
     print('ROI event balance: {} in, {} out.'.format(len(unev), nout))
                    

--- a/bye_splits/tasks/roi.py
+++ b/bye_splits/tasks/roi.py
@@ -112,7 +112,7 @@ def roi(pars, df_gen, df_cl, df_tc, **kw):
         roi_tcs['wght_y'] = divz(ev_tc.tc_y)
 
         keybase = kw['FesAlgo'] + '_' + str(ev) + '_'
-        keytc = keybase + 'tc'
+        keytc = keybase + 'group'
         store_tc[keytc] = roi_tcs
         store_tc[keytc].attrs['columns'] = roi_keep
         store_tc[keytc + 'central'] = uvcentral

--- a/bye_splits/tasks/seed.py
+++ b/bye_splits/tasks/seed.py
@@ -8,11 +8,12 @@ parent_dir = os.path.abspath(__file__ + 3 * '/..')
 sys.path.insert(0, parent_dir)
 
 import bye_splits
-from bye_splits.utils import common
+from bye_splits.utils import common, params
 
 import re
 import numpy as np
 import h5py
+import yaml
 
 def validation(mipPts, event, infile, outfile, nbinsrz, nbinsphi):
     """Compares all values of 2d histogram between local and CMSSW versions."""

--- a/bye_splits/tasks/seed_roi.py
+++ b/bye_splits/tasks/seed_roi.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-_all_ = [ 'seed_roi' ]
+_all_ = [ 'seed_roi', 'dist' ]
 
 import os
 import sys
@@ -11,11 +11,23 @@ import bye_splits
 from bye_splits.utils import common, params
 
 import re
+import yaml
 import numpy as np
 import h5py
 import pandas as pd
 
+def add_centrals_wafer_info(roi_ev, centr):
+    roi_ev['is_central'] = 0
+    iscentral = (roi_ev.tc_wu==centr[0]) & (roi_ev.tc_wv==centr[1])
+    roi_ev.loc[iscentral, 'is_central'] = 1
+    return roi_ev
+
 def calc_universal_coordinates(df, varu='univ_u', varv='univ_v'):
+    """
+    Places all cells from different wafers into the same u/v coordinate system.
+    Trims the dataframe around the central ROI wafer in the u/v space,
+    according to the seeding window size.
+    """
     nside = 4
     df[varu] = df.tc_cu - nside*df.tc_wu + 2*nside*df.tc_wv
     df[varv] = df.tc_cv - 2*nside*df.tc_wu + nside*df.tc_wv
@@ -23,19 +35,28 @@ def calc_universal_coordinates(df, varu='univ_u', varv='univ_v'):
     df[varv] = df[varv] - df[varv].min()
     return df
 
-def create_histo_uv(arr, fill):
+def create_histo_uv(arr, fill, umin, umax, vmin, vmax):
     """
     Creates a 2D histogram with fixed (u,v) size.
-    The input event must be a 2D array where the inner axis encodes, in order:
-    - 1: TC u
-    - 2: TC v
-    - 3: Value of interest ("counts" of the histogram, the "z axis")
+    - arr: array where the inner axis encodes, in order:
+      - 1: TC u
+      - 2: TC v
+      - 3: Value of interest ("counts" of the histogram, the "z axis")
+    - fill stores the dummy value to fill the histogram
+    - remaining variables serve to cut around the central region of the ROI
     """
-    arr_mins = arr[:,:2].min(axis=0, keepdims=True)
-    arr_bins = arr[:,:2] - arr_mins
-    nu, nv = arr_bins.max(axis=0).astype(np.int32) + 1
+    #arr_mins = arr[:,:2].min(axis=0, keepdims=True)
+    #arr_bins = arr[:,:2] - arr_mins
+    arr_bins_u = arr[:,0] - umin
+    arr_bins_v = arr[:,1] - vmin
+    
+    #nu, nv = arr_bins.max(axis=0).astype(np.int32) + 1
+    nu, nv = umax-umin+1, vmax-vmin+1
+    
     arr_vals = arr[:,2]
-    arr = np.concatenate((arr_bins,np.expand_dims(arr_vals, axis=1)), axis=1)
+    arr = np.concatenate((np.expand_dims(arr_bins_u, axis=1),
+                          np.expand_dims(arr_bins_v, axis=1),
+                          np.expand_dims(arr_vals, axis=1)), axis=1)
     # bin_eff = arr.shape[0] / (nu*nv)
     # print('bin efficiency: {}'.format(bin_eff))
 
@@ -43,71 +64,107 @@ def create_histo_uv(arr, fill):
     for b in arr[:]:
         ubin = int(b[0])
         vbin = int(b[1])
+        if ubin<0 or vbin<0 or ubin>(umax-umin) or vbin>(vmax-vmin):
+            continue
         h[ubin,vbin] = b[2]
-
     return h
 
+def define_histo_cuts(roi_df, centrals, wsizeu, wsizev, varu, varv):
+    """
+    Define u/v cuts to be applied to the histogram.
+    - roi_df: dataframe containing all TCs of a ROIclOut
+    - centrals: u/v of the central wafer of the ROI
+    - wsize: seeding window size    
+    """
+    central_df = roi_df[(roi_df.tc_wu==centrals[0]) & (roi_df.tc_wv==centrals[1])][[varu,varv]]
+    maxs = central_df.max() + np.array([wsizeu,wsizev])
+    mins = central_df.min() - np.array([wsizeu,wsizev])
+    return maxs, mins
+
+def dist(u1, v1, u2, v2):
+    """distance in an hexagonal grid"""
+    s1 = u1 - v1
+    s2 = u2 - v2
+    return (abs(u1-u2) + abs(v1-v2) + abs(s1-s2)) / 2
+
 def seed_roi(pars, debug=False, **kw):
-    uv_vars = ['univ_u', 'univ_v', 'tc_cu', 'tc_cv', 'tc_wu', 'tc_wv']
+    with open(params.CfgPath, 'r') as afile:
+        cfg = yaml.safe_load(afile)
+
+    uv_vars = ['univ_u', 'univ_v', 'tc_cu', 'tc_cv']
     in_tcs = common.fill_path(kw['SeedIn'], **pars)
-    out_seeds = common.fill_path(kw['SeedOut'], **pars)
-    window_u = pars['seed_window']
-    window_v = pars['seed_window']
+    extra_name = '_hexdist' if cfg['seed_roi']['hexDist'] else ''
+    out_seeds = common.fill_path(kw['SeedOut'] + extra_name, **pars)
+    window = pars['seed_window']
 
     store_roi = pd.HDFStore(in_tcs, mode='r')
     store_seeds = h5py.File(out_seeds, mode='w')
-    unev = store_roi.keys()
+    unev = [s for s in store_roi.keys() if 'central' not in s]
     for key in unev:
-        roi_ev = store_roi[key]
-        roi_ev = calc_universal_coordinates(roi_ev, varu=uv_vars[0], varv=uv_vars[1])
+        inevent = store_roi[key]
+        roi_uvcentrals = store_roi[key + 'central'].to_numpy()
+        rois_ev = {roi_id: sub_df for roi_id, sub_df in inevent.groupby("roi_id")}
 
-        # sum over layers
-        group = roi_ev.groupby(by=uv_vars).sum()[['tc_mipPt', 'wght_x', 'wght_y']]
-        group.loc[:, ['wght_x', 'wght_y']] = group.loc[:, ['wght_x', 'wght_y']].div(group.tc_mipPt, axis=0)
-        group = group.reset_index()
-
-        roi_ev = group[['tc_cu', 'tc_cv', 'tc_mipPt', 'wght_x', 'wght_y']].to_numpy()
-
-        energies = create_histo_uv(roi_ev[:,[0,1,2]], fill=0.)
-        wght_x   = create_histo_uv(roi_ev[:,[0,1,3]], fill=np.nan)
-        wght_y   = create_histo_uv(roi_ev[:,[0,1,4]], fill=np.nan)
-
-        surroundings = []
- 
-        # add unphysical top and bottom u rows and v columns TCs in the edge
-        # fill the rows with negative (unphysical) energy values
-        # boundary conditions on the phi axis are satisfied by 'np.roll'
-        energies = np.pad(energies, pad_width=(window_u, window_v),
-                          constant_values=(-1,-1))
+        seeds = [np.array([]) for _ in range(3)] # data storage per event
         
-        # slice to remove padding
-        slc = np.index_exp[window_u:energies.shape[0]-window_u,
-                           window_v:energies.shape[1]-window_v]
-    
-        # note: energies is by definition larger or equal to itself
-        for iu in range(-window_u, window_u+1):
-            for iv in range(-window_v, window_v+1):
-                # if iu == 2 and iv == 2: CHANGE!!!!!!!!!!!!!!!!!!!!!!!
-                #     continue
-                surroundings.append(np.roll(energies, shift=(iu,iv), axis=(0,1))[slc])
- 
-        energies = energies[slc]
- 
-        maxima = (energies > kw['histoThreshold'] )
-        for surr in surroundings:
-            maxima = maxima & (energies >= surr)
+        for roi_ev, centrals in zip(rois_ev.values(), roi_uvcentrals):
+            roi_ev = roi_ev.drop(['roi_id'], axis=1)
+            roi_ev = calc_universal_coordinates(roi_ev, varu=uv_vars[0], varv=uv_vars[1])
+            roi_ev = add_centrals_wafer_info(roi_ev, centrals)
+            maxcuts, mincuts = define_histo_cuts(roi_ev, centrals, window, window,
+                                                 varu=uv_vars[0], varv=uv_vars[1])
 
-        seeds_idx = np.nonzero(maxima)
-        res = [energies[seeds_idx], wght_x[seeds_idx], wght_y[seeds_idx]]
+            # sum over layers
+            group = roi_ev.groupby(by=uv_vars).sum()[['tc_mipPt', 'wght_x', 'wght_y', 'is_central']]
+            group.loc[:, ['wght_x', 'wght_y']] = group.loc[:, ['wght_x', 'wght_y']].div(group.tc_mipPt, axis=0)
+            group = group.reset_index()
+            roi_ev = group[[uv_vars[0], uv_vars[1], 'tc_mipPt', 'wght_x', 'wght_y', 'is_central']].to_numpy()
 
+            cuts = dict(umin=mincuts[0], umax=maxcuts[0], vmin=mincuts[1], vmax=maxcuts[1])
+            energies  = create_histo_uv(roi_ev[:,[0,1,2]], fill=0., **cuts)
+            wght_x    = create_histo_uv(roi_ev[:,[0,1,3]], fill=np.nan, **cuts)
+            wght_y    = create_histo_uv(roi_ev[:,[0,1,4]], fill=np.nan, **cuts)
+            iscentral = create_histo_uv(roi_ev[:,[0,1,5]], fill=0., **cuts)
+            surroundings = []
+     
+            # slice to remove the included in histogram
+            slc = np.index_exp[window:energies.shape[0]-window,
+                               window:energies.shape[1]-window]
+        
+            # note: energies is by definition larger or equal to itself
+            for iu in range(-window, window+1):
+                for iv in range(-window, window+1):
+                    if cfg['seed_roi']['hexDist'] and dist(iu,iv,0,0) > window:
+                        continue
+                    surroundings.append(np.roll(energies, shift=(iu,iv), axis=(0,1))[slc])
+
+            energies  = energies[slc]
+            wght_x    = wght_x[slc]
+            wght_y    = wght_y[slc]
+            iscentral = iscentral[slc]
+     
+            maxima = energies > kw['histoThreshold']
+            for surr in surroundings:
+                maxima = maxima & (energies >= surr)
+
+            # iscentral > 0 indicates the u/v bin belongs to the central wafer of the ROI
+            maxima = maxima & (iscentral > 0)
+                
+            seeds_idx = np.nonzero(maxima)
+            ev_seeds = [energies[seeds_idx], wght_x[seeds_idx], wght_y[seeds_idx]]
+
+            # join seeds in the same event from different ROIs
+            for ientry in range(len(ev_seeds)):
+                seeds[ientry] = np.hstack((seeds[ientry],ev_seeds[ientry]))
+            
         if debug:
-            print('Ev: {}'.format(event_number))
+            print('Key: {}'.format(key))
             print('Seeds bins: {}'.format(seeds_idx))
             print('NSeeds={}\tMipPt={}\tX={}\tY={}'.format(len(res[0]),res[0],res[1],res[2])) 
 
-        store_seeds[key] = res
+        store_seeds[key] = seeds
         store_seeds[key].attrs['columns'] = ['seedEn', 'seedXdivZ', 'seedYdivZ']
-        store_seeds[key].attrs['doc'] = "Seeds' nergies and projected positions in {}.".format(key)
+        store_seeds[key].attrs['doc'] = "Seeds' energies and projected positions in {}.".format(key)
 
     nout = len(store_seeds.keys())
     store_roi.close()

--- a/bye_splits/tasks/validation.py
+++ b/bye_splits/tasks/validation.py
@@ -172,7 +172,7 @@ def stats_collector(pars, mode='resolution', debug=True, **kw):
                 print('Suprise')
                 raise ValueError()
 
-            elif len(cmsswEta) == 2:
+            if len(cmsswEta) == 2:
                 evsplits['cmssw'].append(event_number)
             elif len(cmsswEta) != 1:
                 print('Suprise')
@@ -182,6 +182,7 @@ def stats_collector(pars, mode='resolution', debug=True, **kw):
         c_loc2 = len(evsplits['local'])
         c_cms1 = ntotal-len(evsplits['cmssw'])
         c_cms2 = len(evsplits['cmssw'])
+
         locrat1 = float(c_loc1)/ntotal
         locrat2 = float(c_loc2)/ntotal
         cmsrat1 = float(c_cms1)/ntotal
@@ -189,10 +190,15 @@ def stats_collector(pars, mode='resolution', debug=True, **kw):
 
         if debug:
             print()
-            print('CMMSW ratio singletons: {} ({})'.format(cmsrat1, c_cms1))
-            print('CMSSW ratio splits: {} ({})'.format(cmsrat2, c_cms2))
-            print('Local ratio singletons: {} ({})'.format(locrat1, c_loc1))
-            print('Local ratio splits: {} ({})'.format(locrat2, c_loc2))
+            print('CMMSW/Custom non-split ratio:\t {}/{}'.format(cmsrat1, locrat1))
+            print('CMSSW/Custom split splits:\t {}/{}'.format(cmsrat2, locrat2))
+
+            print('CMSSW/Custom non-split count:\t {}/{}'.format(c_cms1, c_loc1))
+            print('CMSSW/Custom split count:\t {}/{}'.format(c_cms2, c_loc2))
+
+            print()
+            print('List of split local events: {}'.format(evsplits['local']))
+            print('List of split CMSSW events: {}'.format(evsplits['cmssw']))
 
         if mode == 'resolution':
             ret = pd.DataFrame({'enres_old': enres_old,

--- a/bye_splits/tasks/validation.py
+++ b/bye_splits/tasks/validation.py
@@ -99,6 +99,7 @@ def stats_collector(pars, mode='resolution', debug=True, **kw):
 
         c_loc1, c_loc2 = 0, 0
         c_cmssw1, c_cmssw2 = 0, 0
+        evsplits = {'local': [], 'cmssw': []}
 
         for key1, key2 in zip(local_keys, cmssw_keys):
             local = sloc[key1]
@@ -165,31 +166,31 @@ def stats_collector(pars, mode='resolution', debug=True, **kw):
             else:
                 phires_new.append(_phires_new - gen_phi)
 
-            if len(locEta) == 1:
-                c_loc1 += 1
-            elif len(locEta) == 2:
-                c_loc2 += 1
-            else:
+            if len(locEta) == 2:
+                evsplits['local'].append(event_number)
+            elif len(locEta) != 1:
                 print('Suprise')
                 raise ValueError()
 
-            if len(cmsswEta) == 1:
-                c_cmssw1 += 1
             elif len(cmsswEta) == 2:
-                c_cmssw2 += 1
-            else:
+                evsplits['cmssw'].append(event_number)
+            elif len(cmsswEta) != 1:
                 print('Suprise')
                 raise ValueError()
 
+        c_loc1 = ntotal-len(evsplits['local'])
+        c_loc2 = len(evsplits['local'])
+        c_cms1 = ntotal-len(evsplits['cmssw'])
+        c_cms2 = len(evsplits['cmssw'])
         locrat1 = float(c_loc1)/ntotal
         locrat2 = float(c_loc2)/ntotal
-        cmsswrat1 = float(c_cmssw1)/ntotal
-        cmsswrat2 = float(c_cmssw2)/ntotal
+        cmsrat1 = float(c_cms1)/ntotal
+        cmsrat2 = float(c_cms2)/ntotal
 
         if debug:
             print()
-            print('CMMSW ratio singletons: {} ({})'.format(cmsswrat1, c_cmssw1))
-            print('CMSSW ratio splits: {} ({})'.format(cmsswrat2, c_cmssw2))
+            print('CMMSW ratio singletons: {} ({})'.format(cmsrat1, c_cms1))
+            print('CMSSW ratio splits: {} ({})'.format(cmsrat2, c_cms2))
             print('Local ratio singletons: {} ({})'.format(locrat1, c_loc1))
             print('Local ratio splits: {} ({})'.format(locrat2, c_loc2))
 
@@ -203,8 +204,8 @@ def stats_collector(pars, mode='resolution', debug=True, **kw):
         elif mode == 'ratios':
             ret = pd.DataFrame({'local1': c_loc1,
                                 'local2': c_loc2,
-                                'cmssw1': c_cmssw1,
-                                'cmssw2': c_cmssw2,
+                                'cmssw1': c_cms1,
+                                'cmssw2': c_cms2,
                                 'localrat1': locrat1,
                                 'localrat2': locrat2,
                                 'cmsswrat1': locrat1,

--- a/bye_splits/tasks/validation_roi.py
+++ b/bye_splits/tasks/validation_roi.py
@@ -93,9 +93,9 @@ def stats_collector_roi(pars, mode='resolution', debug=True, **kw):
         cfg = yaml.safe_load(afile)
 
     if cfg['cluster']['ROICylinder']:
-        outcl = common.fill_path(kw['ClusterOutForValidation']  + '_cyl', **pars)
+        outcl = common.fill_path(kw['ClusterOutValidation']  + '_cyl', **pars)
     else:
-        outcl = common.fill_path(kw['ClusterOutForValidation'], **pars)
+        outcl = common.fill_path(kw['ClusterOutValidation'], **pars)
 
     if cfg['cluster']['ROICylinder']:
         outroi = common.fill_path(kw['ROIregionOut'], **pars)

--- a/bye_splits/tasks/validation_roi.py
+++ b/bye_splits/tasks/validation_roi.py
@@ -59,11 +59,11 @@ def stats_collector_seed(pars, debug=False, **kw):
     data = {'nseeds': [], 'nrois': [], 'nseedsperroi': [],
             'genen': [], 'geneta': [], 'genphi': [],}
     
-    search_str = '{}_([0-9]{{1,7}})_tc'.format(kw['FesAlgo'])
+    search_gr = '{}_([0-9]{{1,7}})_group'.format(kw['FesAlgo'])
     
     for ks,kt in zip(kseeds,ktc):
-        evn = re.search(search_str, ks).group(1)
-        assert evn == re.search('/' + search_str, kt).group(1)
+        evn = re.search(search_gr, ks).group(1)
+        assert evn == re.search('/' + search_gr, kt).group(1)
             
         dftc = stc[kt]
         dfseed = sseed[ks]
@@ -108,12 +108,13 @@ def stats_collector_roi(pars, mode='resolution', debug=True, **kw):
     sgen   = pd.HDFStore(outgen, mode='r')
 
     keysroi, keyscl = sroi.keys(), scl.keys()
-    search_str = '{}_([0-9]{{1,7}})_tc'.format(kw['FesAlgo'])
+    search_tc = '{}_([0-9]{{1,7}})_tc'.format(kw['FesAlgo'])
+    search_gr = '{}_([0-9]{{1,7}})_group'.format(kw['FesAlgo'])
     
     # remove ROI keys where no cluster exists
     to_remove = []
     for ik,k in enumerate(keysroi):
-        evn = re.search(search_str, k).group(1)
+        evn = re.search(search_tc, k).group(1)
         if '/ThresholdDummyHistomaxnoareath20_' + evn + '_cl' not in keyscl:
             to_remove.append(k)
     keysroi = list(keysroi)
@@ -151,7 +152,7 @@ def stats_collector_roi(pars, mode='resolution', debug=True, **kw):
         clPhi = dfcl['phi'].to_numpy()
         clEn  = dfcl['en'].to_numpy()
 
-        evn = re.search(search_str, kroi).group(1)
+        evn = re.search(search_tc, kroi).group(1)
         if evn not in kcl:
             breakpoint()
             print('Event {} was not in the cluster dataset.'.format(evn))

--- a/bye_splits/tasks/validation_roi.py
+++ b/bye_splits/tasks/validation_roi.py
@@ -8,24 +8,119 @@ parent_dir = os.path.abspath(__file__ + 3 * '/..')
 sys.path.insert(0, parent_dir)
 
 import bye_splits
-from bye_splits.utils import common
+from bye_splits.utils import common, params
 
 import re
+import yaml
 import numpy as np
 import pandas as pd
 import h5py
 
+def get_gen_info(dfgen, event):
+    genEvent = dfgen[dfgen.event==event]
+
+    genEn  = genEvent['gen_en'].to_numpy()
+    genEta = genEvent['gen_eta'].to_numpy()
+    genPhi = genEvent['gen_phi'].to_numpy()
+    
+    #when the cluster is split we will have two rows
+    if len(genEn) > 1:
+        assert genEn[1]  == genEn[0]
+        assert genEta[1] == genEta[0]
+        assert genPhi[1] == genPhi[0]
+    genEn  = genEn[0]
+    genEta = genEta[0]
+    genPhi = genPhi[0]
+
+    return genEn, genEta, genPhi
+
+def stats_collector_seed(pars, debug=False, **kw):
+    """Statistics collector for ROI seeding results."""
+    if debug:
+        print('Running the seed validation...')
+
+    with open(params.CfgPath, 'r') as afile:
+        cfg = yaml.safe_load(afile)
+
+    extra_name = '_hexdist' if cfg['seed_roi']['hexDist'] else ''
+    outseed = common.fill_path(kw['SeedOut'] + extra_name, **pars)
+    outgen  = common.fill_path(kw['ROIclOut'], **pars)
+    outtc   = common.fill_path(kw['ROItcOut'], **pars)
+    sseed = h5py.File(outseed, mode='r')
+    sgen  = pd.HDFStore(outgen, mode='r')
+    stc   = pd.HDFStore(outtc, mode='r')
+
+    kseeds, ktc = sseed.keys(), stc.keys()
+    ktc = [x for x in ktc if 'central' not in x]
+    
+    ntotal = len(kseeds)
+
+    dfgen = sgen['/df']
+    data = {'nseeds': [], 'nrois': [], 'nseedsperroi': [],
+            'genen': [], 'geneta': [], 'genphi': [],}
+    
+    search_str = '{}_([0-9]{{1,7}})_tc'.format(kw['FesAlgo'])
+    
+    for ks,kt in zip(kseeds,ktc):
+        evn = re.search(search_str, ks).group(1)
+        assert evn == re.search('/' + search_str, kt).group(1)
+            
+        dftc = stc[kt]
+        dfseed = sseed[ks]
+        colsseed = list(dfseed.attrs['columns'])
+
+        nseeds = len(dfseed[:][colsseed.index('seedEn')])
+        nrois = len(dftc['roi_id'].unique())
+        genEn, genEta, genPhi = get_gen_info(dfgen, int(evn))
+
+        data['genen'].append(genEn)
+        data['geneta'].append(genEta)
+        data['genphi'].append(genPhi)
+        data['nseeds'].append(nseeds)
+        data['nrois'].append(nrois)
+        data['nseedsperroi'].append(float(nseeds) / nrois)
+
+    ret = pd.DataFrame(data)
+
+    stc.close()
+    sgen.close()
+    sseed.close()
+    return ret
+
 def stats_collector_roi(pars, mode='resolution', debug=True, **kw):
-    """Statistics collector used for phi bin optimization."""
-    outcl  = common.fill_path(kw['ClusterOutForValidation'], **pars)
-    outroi = common.fill_path(kw['ROIregionOut'], **pars)
+    """Statistics collector for ROI clustering results."""
+    with open(params.CfgPath, 'r') as afile:
+        cfg = yaml.safe_load(afile)
+
+    if cfg['cluster']['ROICylinder']:
+        outcl = common.fill_path(kw['ClusterOutForValidation']  + '_cyl', **pars)
+    else:
+        outcl = common.fill_path(kw['ClusterOutForValidation'], **pars)
+
+    if cfg['cluster']['ROICylinder']:
+        outroi = common.fill_path(kw['ROIregionOut'], **pars)
+    else:
+        outroi = common.fill_path(kw['ROItcOut'], **pars)
     outgen = common.fill_path(kw['ROIclOut'], **pars)
+
     scl    = pd.HDFStore(outcl, mode='r')
     sroi   = h5py.File(outroi, mode='r')
     sgen   = pd.HDFStore(outgen, mode='r')
 
     keysroi, keyscl = sroi.keys(), scl.keys()
-    assert(len(keysroi) == len(keyscl))
+    search_str = '{}_([0-9]{{1,7}})_tc'.format(kw['FesAlgo'])
+    
+    # remove ROI keys where no cluster exists
+    to_remove = []
+    for ik,k in enumerate(keysroi):
+        evn = re.search(search_str, k).group(1)
+        if '/ThresholdDummyHistomaxnoareath20_' + evn + '_cl' not in keyscl:
+            to_remove.append(k)
+    keysroi = list(keysroi)
+    for i in to_remove:
+        keysroi.remove(i)
+    assert len(keysroi) == len(keyscl)
+
     ntotal = len(keyscl)
 
     dfgen = sgen['/df']
@@ -39,12 +134,15 @@ def stats_collector_roi(pars, mode='resolution', debug=True, **kw):
             'nclusters': []}
 
     c_cl1, c_cl2 = 0, 0
-    search_str = '{}_([0-9]{{1,7}})_tc'.format(kw['FesAlgo'])
     
-    for kroi, kcl in zip(keysroi, keyscl):    
+    for kroi, kcl in zip(keysroi, keyscl):
         dfroi = sroi[kroi]
         dfcl = scl[kcl]
+        if dfcl.empty:
+            continue
+
         colsroi = list(dfroi.attrs['columns'])
+
         roiEta  = dfroi[:, colsroi.index('tc_eta')].mean()
         roiPhi  = dfroi[:, colsroi.index('tc_phi')].mean()
         roiEn   = dfroi[:, colsroi.index('tc_energy')].sum()
@@ -54,21 +152,12 @@ def stats_collector_roi(pars, mode='resolution', debug=True, **kw):
         clEn  = dfcl['en'].to_numpy()
 
         evn = re.search(search_str, kroi).group(1)
-        genEvent = dfgen[dfgen.event==int(evn)]
-        
-        genEn  = genEvent['gen_en'].to_numpy()
-        genEta = genEvent['gen_eta'].to_numpy()
-        genPhi = genEvent['gen_phi'].to_numpy()
-        
-        #when the cluster is split we will have two rows
-        if len(genEn) > 1:
-            assert genEn[1]  == genEn[0]
-            assert genEta[1] == genEta[0]
-            assert genPhi[1] == genPhi[0]
-        genEn  = genEn[0]
-        genEta = genEta[0]
-        genPhi = genPhi[0]
-                                    
+        if evn not in kcl:
+            breakpoint()
+            print('Event {} was not in the cluster dataset.'.format(evn))
+            continue
+        genEn, genEta, genPhi = get_gen_info(dfgen, int(evn))
+
         # ignoring the lowest energy clusters when there is a splitting
         clEnMax = max(clEn)
         index_max_energy_cl = np.where(clEn==clEnMax)[0][0]
@@ -77,6 +166,11 @@ def stats_collector_roi(pars, mode='resolution', debug=True, **kw):
         clEtaMax = clEta[index_max_energy_cl]
         clPhiMax = clPhi[index_max_energy_cl]
 
+        # test if cluster multiplicity affects results (answer: no!)
+        # clEnMax = sum(clEn)
+        # if len(clEn) > 1:
+        #     print(max(clEn) / sum(clEn))
+            
         data['genen'].append(genEn)
         data['geneta'].append(genEta)
         data['genphi'].append(genPhi)
@@ -86,11 +180,11 @@ def stats_collector_roi(pars, mode='resolution', debug=True, **kw):
         data['clen'].append(clEnMax)
         data['cleta'].append(clEtaMax)
         data['clphi'].append(clPhiMax)
-        data['resroien'].append(roiEn/genEn - 1.)
-        data['resclen'].append(clEnMax/genEn - 1.)
-        data['resroieta'].append(roiEta/genEta - 1.)
+        data['resroien'].append(roiEn/genEn     - 1.)
+        data['resclen'].append(clEnMax/genEn    - 1.)
+        data['resroieta'].append(roiEta/genEta  - 1.)
         data['rescleta'].append(clEtaMax/genEta - 1.)
-        data['resroiphi'].append(roiEn/genPhi - 1.)
+        data['resroiphi'].append(roiPhi/genPhi  - 1.)
         data['resclphi'].append(clPhiMax/genPhi - 1.)
         data['nclusters'].append(len(clEn))
         # etares_old.append( etaClMax - genEta )
@@ -108,7 +202,7 @@ def stats_collector_roi(pars, mode='resolution', debug=True, **kw):
         #     phires['roi'].append(phiRoiMax + 2*np.pi - genPhi)
         # else:
         #     phires['roi'].append(phiRoiMax - genPhi)
-                        
+
     clrat1 = float(c_cl1) / ntotal
     clrat2 = float(c_cl2) / ntotal
 
@@ -123,7 +217,6 @@ def stats_collector_roi(pars, mode='resolution', debug=True, **kw):
     scl.close()
     sroi.close()
     sgen.close()
-
     return ret
 
 if __name__ == "__main__":

--- a/bye_splits/utils/common.py
+++ b/bye_splits/utils/common.py
@@ -29,6 +29,9 @@ def calcRzFromEta(eta):
     _theta = 2 * np.arctan(np.exp(-1 * eta))
     return np.tan(_theta)
 
+def create_dir(p):
+    if not os.path.exists(p):
+        os.makedirs(p)
 
 class dot_dict(dict):
     """dot.notation access to dictionary attributes"""
@@ -36,7 +39,6 @@ class dot_dict(dict):
     __getattr__ = dict.get
     __setattr__ = dict.__setitem__
     __delattr__ = dict.__delitem__
-
 
 def fill_path(base_path, data_dir=params.LocalStorage, ext="hdf5", **kw):
     """Create unique file name base on user input parameters."""

--- a/bye_splits/utils/parsing.py
+++ b/bye_splits/utils/parsing.py
@@ -8,7 +8,6 @@ import sys
 parent_dir = os.path.abspath(__file__ + 3 * "/..")
 sys.path.insert(0, parent_dir)
 
-
 def add_parameters(parser):
     parser.add_argument(
         "--sel",

--- a/config.yaml
+++ b/config.yaml
@@ -48,7 +48,7 @@ varEvents:
     z: 'good_tc_z'
     phi: 'good_tc_phi'
     eta: 'good_tc_eta'
-    idcl: 'good_tc_cluster_id'
+    idcl: 'good_tc_multicluster_id'
     pt: 'good_tc_pt'
     en: 'good_tc_mipPt'
     en_gev: 'good_tc_energy'
@@ -162,7 +162,7 @@ valid:
   FillOut: 'fill'
 
 valid_cluster:
-  ClusterOutForValidation: 'cluster_valid_roi'
+  ClusterOutValidation: 'cluster_valid_roi'
   ROIclOut: 'roi3d'
   ROIgenOut: 'roigen'
   ROItcOut: 'roiall'

--- a/config.yaml
+++ b/config.yaml
@@ -48,7 +48,7 @@ varEvents:
     z: 'good_tc_z'
     phi: 'good_tc_phi'
     eta: 'good_tc_eta'
-    idcl: 'good_tc_multicluster_id'
+    idcl: 'good_tc_cluster_id'
     pt: 'good_tc_pt'
     en: 'good_tc_mipPt'
     en_gev: 'good_tc_energy'

--- a/config.yaml
+++ b/config.yaml
@@ -48,7 +48,7 @@ varEvents:
     z: 'good_tc_z'
     phi: 'good_tc_phi'
     eta: 'good_tc_eta'
-    idcl: 'good_tc_multicluster_id'
+    idcl: 'good_tc_cluster_id'
     pt: 'good_tc_pt'
     en: 'good_tc_mipPt'
     en_gev: 'good_tc_energy'
@@ -134,7 +134,9 @@ seed:
 
 cluster:
     ClusterInTC: 'fill'
-    ClusterInTCROI: 'roicylinder'
+    ClusterInTCROI: 'roiall'
+    ClusterInTCROICylinder: 'roicylinder'
+    ROICylinder: False
     ClusterInSeeds: 'seed'
     ClusterInSeedsROI: 'seed_roi'
     ClusterOutPlot: 'cluster_plot'
@@ -159,12 +161,18 @@ valid:
   FillOutComp: 'fill_comp'
   FillOut: 'fill'
 
-valid_roi:
+valid_cluster:
   ClusterOutForValidation: 'cluster_valid_roi'
   ROIclOut: 'roi3d'
   ROIgenOut: 'roigen'
-  ROItcOut: 'roitc'
+  ROItcOut: 'roiall'
   ROIregionOut: 'roicylinder'
+
+valid_seed:
+  ROIclOut: 'roi3d'
+  ROIgenOut: 'roigen'
+  ROItcOut: 'roitc'
+  SeedOut: 'seed_roi'
 
 optimization:
   Epochs: 99999
@@ -180,9 +188,11 @@ roi:
   ROIclOut: 'roi3d'
   ROIgenOut: 'roigen'
   ROItcOut: 'roitc'
+  ROItcOut2: 'roiall'
   ROIcylinderOut: 'roicylinder'
   
 seed_roi:
   SeedIn: 'roitc'
   SeedOut: 'seed_roi'
   histoThreshold: 20.
+  hexDist: True

--- a/config.yaml
+++ b/config.yaml
@@ -48,7 +48,7 @@ varEvents:
     z: 'good_tc_z'
     phi: 'good_tc_phi'
     eta: 'good_tc_eta'
-    idcl: 'good_tc_cluster_id'
+    idcl: 'good_tc_multicluster_id'
     pt: 'good_tc_pt'
     en: 'good_tc_mipPt'
     en_gev: 'good_tc_energy'


### PR DESCRIPTION
This PR brings the full ROI chain with a new seeding:
- fully functional hexagonal seeding
- clustering on the x/z,y/z space taking ROI seeds and ROI TCs (or all TCs if preferred) as input
- resolution and distribution plotting utilities, including interactive visualization of hexagonal grids and events

- important fix for the "max_energy" clustering algorithm (see ```bye_splits/tasks/cluster.py```): the old version assigns all TCs (withing a maximum distance) to the same, most-energetic seed. The new version correctly prioritizes seeds based on energy, so that the seeds that are not the most energetic are still assigned some TCs.

The chain was tested with multiple parameters from start to finish.

![Screenshot from 2023-04-09 23-24-26](https://user-images.githubusercontent.com/20703947/230797179-a37afbf7-0198-48b4-a988-72be9ea03cbd.png)

![Screenshot from 2023-04-09 23-26-38](https://user-images.githubusercontent.com/20703947/230797274-b6540ded-132e-4b90-b441-a7ec160ecc6d.png)
