### PR TITLE
New reconstruction chain in the webApp

### DIFF
--- a/bye_splits/plot/display_plotly/plot_event.py
+++ b/bye_splits/plot/display_plotly/plot_event.py
@@ -14,13 +14,17 @@ from bye_splits.tasks.coarse_seeding import cs_dummy_calculator
 def geom_selection(df_dict):
     gen_info = next(reversed(df_dict.values()))
 
-    radius_gen = 50 # radius to select a specific region around the gen
-    for coef in list(df_dict.keys())[:-1]:
-        eta = gen_info['gen_eta'].values[0]
-        phi = gen_info['gen_phi'].values[0]
-        x_gen, y_gen = sph2cart(eta, phi)
-        df_dict[coef] = df_dict[coef][np.sqrt((x_gen-df_dict[coef].tc_x)**2+(y_gen-df_dict[coef].tc_y)**2)<radius_gen]
+    radius_gen = 40  # radius to select a specific region around the gen
+    for chain in df_dict.keys():
+        for coef in list(df_dict[chain].keys()):
+            eta = gen_info['gen_eta'].values[0]
+            phi = gen_info['gen_phi'].values[0]
+            x_gen, y_gen = sph2cart(eta, phi)
 
+            mask = np.sqrt((x_gen - df_dict[chain][coef]['tc_x'])**2 + \
+                           (y_gen - df_dict[chain][coef]['tc_y'])**2) < radius_gen
+            df_dict[chain][coef] = df_dict[chain][coef][mask].reset_index(drop=True)
+    
     return df_dict
 
 def prepare_slider(df, page='3D'):
@@ -140,7 +144,7 @@ def produce_plot(df, opacity, plot_type, discrete):
             cmin=df.tc_mipPt.min(),
             cmax=df.tc_mipPt.max(),
             showscale=True,
-            colorbar=dict(title=dict(text="[mip\u209c]", side="right"), ticks="outside", x=1)
+            colorbar=dict(title=dict(text='Transverse mip', font=dict(size=16), side="right"), ticks="outside", x=1)
         ))
         listdata.append(datum)
     return listdata

--- a/bye_splits/scripts/run_radii_chain.py
+++ b/bye_splits/scripts/run_radii_chain.py
@@ -23,43 +23,89 @@ from tasks import validation
 import argparse
 import pandas as pd
 
-def run_radii_chain(pars, particles, pu, coefs, event=None):
-    df_gen, df_cl, df_tc = get_data_reco_chain_start(nevents=30, reprocess=False, particles=particles, pu=pu, event=event)
+with open(params.CfgPath, "r") as afile:
+    cfg = yaml.safe_load(afile)
 
-    fill_d = params.read_task_params("fill")
-    tasks.fill.fill(pars, df_gen, df_cl, df_tc, **fill_d)
-
-    smooth_d = params.read_task_params("smooth")
-    tasks.smooth.smooth(pars, **smooth_d)
-
-    seed_d = params.read_task_params("seed")
-    tasks.seed.seed(pars, **seed_d)
-
-    cluster_d = params.read_task_params("cluster")
-    dict_cluster = {}
+def get_cluster_data(cluster_params, chain, coefs, pars):
+    cluster_data = {}
+    
     for coef in coefs:
-        cluster_d["CoeffA"] = [coef, 0] * 50
-        nevents = tasks.cluster.cluster_default(pars, **cluster_d)
-        store_file = pd.HDFStore(common.fill_path(cluster_d["ClusterOutPlot"], **pars), mode='r')
+        cluster_params["CoeffA"] = [coef, 0] * 50
+        if chain == 'default': 
+            nevents = tasks.cluster.cluster_default(pars, **cluster_params)
+            store_file = pd.HDFStore(common.fill_path(cluster_params["ClusterOutPlot"], **pars), mode='r')
+        else:
+            nevents = tasks.cluster.cluster_cs(pars, **cluster_params)
+            store_file = pd.HDFStore(common.fill_path(cluster_params["ClusterOutPlotCS"], **pars), mode='r')
+        
+        # Extract coefs and events
         df_list = []
         filtered_keys = [key for key in store_file.keys() if key.startswith('/df_')]
         events = [int(key.split('df_')[1]) for key in filtered_keys]
+
         for key in filtered_keys:
             df = store_file.get(key)
             df_list.append(df)
-        dict_cluster[str(coef)[2:]] = df_list
-        store_file.close() 
 
+        cluster_data[str(coef)[2:]] = df_list
+        store_file.close()
+    
+    return cluster_data, events
+
+def merge_cluster_data_with_event(df_event_tc, cluster_data, index):
+    """ data processed from clustering step is merged with original data events
+        to get infomation about the non-clusterised TCs """
+    merged_data = {}
+    
+    for coef in cluster_data.keys():
+        merged_data[coef] = pd.merge(
+            left=cluster_data[coef][index],
+            right=df_event_tc[~df_event_tc['tc_layer'].isin(cfg['selection']['disconnectedTriggerLayers'])],
+            on=['tc_wu', 'tc_wv', 'tc_cu', 'tc_cv', 'tc_layer'],
+            how='outer'
+        ).fillna(cluster_data[coef][index]['seed_idx'].max() + 1)
+    
+    return merged_data
+
+def run_radii_chain(pars, particles, pu, coefs, event=None):
+    df_gen, df_cl, df_tc = get_data_reco_chain_start(nevents=30, reprocess=False, particles=particles, pu=pu, event=event)
+
+    # Default chain
+    fill_params = params.read_task_params("fill")
+    tasks.fill.fill(pars, df_gen, df_cl, df_tc, **fill_params)
+
+    smooth_params = params.read_task_params("smooth")
+    tasks.smooth.smooth(pars, **smooth_params)
+
+    seed_params = params.read_task_params("seed")
+    tasks.seed.seed(pars, **seed_params)
+
+    cluster_params = params.read_task_params("cluster")
+    cluster_data_default, _ = get_cluster_data(cluster_params, 'default', coefs, pars)
+
+    # Coarse seeding chain
+    fill_cs_params = params.read_task_params('cs')
+    tasks.coarse_seeding.coarse_seeding(pars, df_gen, df_cl, df_tc, **fill_cs_params)
+
+    seed_cs_params = params.read_task_params('seed_cs')
+    tasks.seed_cs.seed_cs(pars, **seed_cs_params)
+
+    cluster_params = params.read_task_params("cluster")
+    cluster_data_cs, events = get_cluster_data(cluster_params, 'cs', coefs, pars)
+
+    # Data unpacker
     dict_event = {}
+    
     for index, ev in enumerate(events):
         dict_event[ev] = {}
-        df_event_tc = df_tc[df_tc.event == ev][['tc_mipPt','tc_eta','tc_wu','tc_wv','tc_cu','tc_cv','tc_layer']]
-        for coef in dict_cluster.keys():
-            dict_event[ev][coef] = pd.merge(left=dict_cluster[coef][index], 
-                                            right=df_event_tc[df_event_tc.tc_layer%2 != 0], 
-                                            on=['tc_wu', 'tc_wv', 'tc_cu', 'tc_cv', 'tc_layer'],
-                                            how='outer').fillna(dict_cluster[coef][index]['seed_idx'].max()+1) 
+        df_event_tc = df_tc[df_tc.event == ev][['tc_mipPt', 'tc_eta', 'tc_wu', 'tc_wv', 'tc_cu', 'tc_cv', 'tc_layer']]
+        
+        # Merge cluster data with event data
+        dict_event[ev]['default'] = merge_cluster_data_with_event(df_event_tc, cluster_data_default, index)
+        dict_event[ev]['cs'] = merge_cluster_data_with_event(df_event_tc, cluster_data_cs, index)
+
     return dict_event, df_gen
+
 
 if __name__ == "__main__":
     FLAGS = parsing.parser_radii_chain()

--- a/config.yaml
+++ b/config.yaml
@@ -125,15 +125,15 @@ varGeometry:
 
 3Ddisplay:
   PU0:
-    photons: 'photons_0PU_cluster.hdf5'
-    electrons: 'electrons_0PU_cluster.hdf5'
-    pions: 'pions_0PU_cluster.hdf5'
+    photons: 'photons_0PU_cluster'
+    electrons: 'electrons_0PU_cluster'
+    pions: 'pions_0PU_cluster'
   PU200:
-    photons: 'photons_200PU_cluster.hdf5'
-    electrons: 'electrons_200PU_cluster.hdf5'
-    pions: 'pions_200PU_cluster.hdf5'
+    photons: 'photons_200PU_cluster'
+    electrons: 'electrons_200PU_cluster'
+    pions: 'pions_200PU_cluster'
   reprocess: False
-  coefs: [0.006,0.010,0.014,0.018,0.022,0.026,0.030]
+  coefs: [0.010, 0.015, 0.020, 0.025]
 
 clusterStudies:
   localDir: /home/llr/cms/mchiusi/event_display/bye_splits/data/new_algos/


### PR DESCRIPTION
In this PR, I have added the possibility to run the **new reconstruction chain** from the 3D display app, allowing users to view its outputs on the screen. Users now have the option to display cluster seeds from the new reconstruction chain, which includes the _new coarse seeding_ and the _new seeding algorithm_, or from the default chain by simply interacting with a switch.

The scripts required to run the new reconstruction chain were already present in the Python framework. When calling for new events from the app, both chains are executed, so that the final user can compare the two chains applied to the same event. The `new_radii_chain` function has been updated accordingly. The dataframes are then processed and stored in the usual hdf5 files, where a new key has been added. This key allows for distinguishing between the new chain and the default chain and can assume the values of 'new' or 'default'.

Here's an example of a photon (200 pileup) processed by both chains. The difference in performance is truly impressive.
![image](https://github.com/bfonta/bye_splits/assets/67897021/c78147f2-af50-4191-af08-18d1b8317d87)
![image](https://github.com/bfonta/bye_splits/assets/67897021/b4283b4b-73cc-4c2b-a0bd-e4def4273b5c)